### PR TITLE
Add default `version` feature, to support building without `shadow-rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rustls = { version = "0.21.12", features = ["dangerous_configuration"] }
 rusty-fork = "0.3.0"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
-shadow-rs = "0.36.0"
+shadow-rs = { version = "0.36.0", optional = true }
 simple_moving_average = "1.0.2"
 tempfile = "3.14.0"
 thiserror = "2.0.3"
@@ -76,10 +76,13 @@ once_cell = "1.20.2"
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [build-dependencies]
-shadow-rs = "0.36.0"
+shadow-rs = { version = "0.36.0", optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [features]
+default = ["version"]
 e2e_test = []
+# Add detailed build information to the CLI version output
+version = ["dep:shadow-rs"]

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "version")]
 fn main() -> shadow_rs::SdResult<()> {
     shadow_rs::new()
 }
+#[cfg(not(feature = "version"))]
+fn main() {}

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -10,6 +10,7 @@ use clap::builder::{ArgPredicate, NonEmptyStringValueParser};
 use clap::Parser;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 use regex::Regex;
+#[cfg(feature = "version")]
 use shadow_rs::shadow;
 
 use crate::config::args::value_parser::{
@@ -105,10 +106,11 @@ const LOCAL_STORAGE_SPECIFIED_WITH_SSE_C: &str =
 const NO_SOURCE_CREDENTIAL_REQUIRED: &str = "no source credential required\n";
 const NO_TARGET_CREDENTIAL_REQUIRED: &str = "no target credential required\n";
 
+#[cfg(feature = "version")]
 shadow!(build);
 
 #[derive(Parser, Clone, Debug)]
-#[command(version=format!("{} ({} {}), {}", build::PKG_VERSION, build::SHORT_COMMIT, build::BUILD_TARGET, build::RUST_VERSION))]
+#[cfg_attr(feature = "version", command(version=format!("{} ({} {}), {}", build::PKG_VERSION, build::SHORT_COMMIT, build::BUILD_TARGET, build::RUST_VERSION)))]
 pub struct CLIArgs {
     #[arg(env, help = "s3://<BUCKET_NAME>[/prefix] or local path", value_parser = storage_path::check_storage_path, default_value_if("auto_complete_shell", ArgPredicate::IsPresent, "s3://ignored"), required = false)]
     source: String,


### PR DESCRIPTION
This PR adds a default feature: `version`, that when disabled removes `shadow-rs` from the dependency tree. This is a non-breaking change because the feature is enabled by default.