### PR TITLE
Fix conditional compilation of build script without version feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --verbose
       - run: cargo build --target ${{ matrix.target }} --verbose
       - run: cargo test  --target ${{ matrix.target }} --verbose
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
-use shadow_rs::ShadowBuilder;
-
 #[cfg(feature = "version")]
 fn main() {
+    use shadow_rs::ShadowBuilder;
     ShadowBuilder::builder().build().unwrap();
 }
 #[cfg(not(feature = "version"))]


### PR DESCRIPTION
The build script fails when building without the `version` feature:
```
/s3sync-1.7.0/build.rs:1:5
  |
1 | use shadow_rs::ShadowBuilder;
  |     ^^^^^^^^^ use of undeclared crate or module `shadow_rs`
```
This PR moves the `shadow_rs` include inside the conditional block. It also adds a `--no-default-features` build step to CI to prevent these types of regressions.