### PR TITLE
Update/v1.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.1] - 2026-03-28
+
+### Changed
+
+- Updated dependencies
+- Switch Dockerfile builder image from `debian:trixie` with manual rustup to `rust:1-trixie`
+
 ## [1.57.0] - 2026-03-20
 
 ### Added
 
-- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline (default: 10000ms, 0 to disable)
+- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline (
+  default: 10000ms, 0 to disable)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+    "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -389,7 +389,7 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1",
+    "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -853,9 +853,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2129,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2575,6 +2575,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -2700,7 +2701,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.57.0"
+version = "1.57.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2743,7 +2744,7 @@ dependencies = [
  "pin-project",
  "regex",
  "rusty-fork",
- "sha1",
+    "sha1 0.11.0",
  "sha2 0.11.0",
  "shadow-rs",
  "simple_moving_average",
@@ -2908,6 +2909,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+    "cfg-if",
+    "cpufeatures 0.3.0",
+    "digest 0.11.2",
 ]
 
 [[package]]
@@ -3263,18 +3275,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3284,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -3500,9 +3512,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3587,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3600,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3610,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3623,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
-    "sha1 0.10.6",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -389,7 +389,7 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
-    "sha1 0.10.6",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -2575,7 +2575,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
-    "wasm-bindgen",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2744,7 +2744,7 @@ dependencies = [
  "pin-project",
  "regex",
  "rusty-fork",
-    "sha1 0.11.0",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "shadow-rs",
  "simple_moving_average",
@@ -2917,9 +2917,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
-    "cfg-if",
-    "cpufeatures 0.3.0",
-    "digest 0.11.2",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.57.0"
+version = "1.57.1"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."
@@ -52,7 +52,7 @@ pin-project = "1.1.11"
 percent-encoding = "2.3.2"
 regex = "1.12.3"
 rusty-fork = "0.3.1"
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 sha2 = "0.11.0"
 shadow-rs = { version = "1.7.1", optional = true }
 simple_moving_average = "1.0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1-trixie AS builder
 WORKDIR /s3sync
 COPY . ./
-RUN git config --global --add safe.directory /s3rm \
+RUN git config --global --add safe.directory /s3sync \
 && cargo build --release
 
 FROM debian:trixie-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-FROM debian:trixie AS builder
+FROM rust:1-trixie AS builder
 WORKDIR /s3sync
 COPY . ./
-RUN apt-get update \
-&& apt-get install --no-install-recommends -y ca-certificates curl build-essential \
-&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >./rust_install.sh \
-&& chmod +x rust_install.sh \
-&& ./rust_install.sh -y \
-&& . "$HOME/.cargo/env" \
-&& rustup update \
+RUN git config --global --add safe.directory /s3rm \
 && cargo build --release
 
 FROM debian:trixie-slim

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@
 # All vulnerability/unsound/notice advisories are errors by default.
 # To ignore a specific advisory, add it here with a reason:
 ignore = [
-    { id = "RUSTSEC-2026-0049", reason = "transitive dep via AWS SDK rustls 0.21; awaiting upstream fix" },
 ]
 
 # ---- 2. Licenses ----

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,47 +1,13 @@
 #![allow(dead_code)]
 #![allow(clippy::assertions_on_constants)]
 
-use anyhow::Result;
-use async_channel::Receiver;
-use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
-use aws_config::{BehaviorVersion, ConfigLoader};
-use aws_sdk_s3::client::Client;
-use aws_sdk_s3::config::Builder;
-use aws_sdk_s3::operation::get_object::GetObjectOutput;
-use aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingOutput;
-use aws_sdk_s3::operation::head_object::HeadObjectOutput;
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::primitives::{DateTime, DateTimeFormat};
-use aws_sdk_s3::types::{
-    BucketInfo, BucketLocationConstraint, BucketType, BucketVersioningStatus, ChecksumMode,
-    CreateBucketConfiguration, DataRedundancy, LocationInfo, LocationType, Object, ObjectVersion,
-    Tag, Tagging, VersioningConfiguration,
-};
-use aws_smithy_types::checksum_config::RequestChecksumCalculation::WhenRequired;
-use aws_types::SdkConfig;
-use filetime::{FileTime, set_file_mtime};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::time;
-use std::time::SystemTime;
 use tokio::sync::Semaphore;
-use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
-use walkdir::DirEntry;
-use walkdir::WalkDir;
 
-use sha2::{Digest, Sha256};
-
-use s3sync::Config;
-use s3sync::config::args::parse_from_args;
-use s3sync::pipeline::Pipeline;
-use s3sync::types::SyncStatistics;
-use s3sync::types::token::create_pipeline_cancellation_token;
+use sha2::Digest;
 
 pub const REGION: &str = "ap-northeast-1";
 pub const EXPRESS_ONE_ZONE_AZ: &str = "apne1-az4";
@@ -1857,7 +1823,10 @@ impl TestHelper {
         }
 
         let hash_result = hasher.finalize();
-        format!("{:x}", hash_result)
+        hash_result
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
     }
 
     pub fn tag_set_to_map(tag_set: &[Tag]) -> HashMap<String, String> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,47 @@
 #![allow(dead_code)]
 #![allow(clippy::assertions_on_constants)]
 
+use anyhow::Result;
+use async_channel::Receiver;
+use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
+use aws_config::{BehaviorVersion, ConfigLoader};
+use aws_sdk_s3::client::Client;
+use aws_sdk_s3::config::Builder;
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
+use aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingOutput;
+use aws_sdk_s3::operation::head_object::HeadObjectOutput;
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::primitives::{DateTime, DateTimeFormat};
+use aws_sdk_s3::types::{
+    BucketInfo, BucketLocationConstraint, BucketType, BucketVersioningStatus, ChecksumMode,
+    CreateBucketConfiguration, DataRedundancy, LocationInfo, LocationType, Object, ObjectVersion,
+    Tag, Tagging, VersioningConfiguration,
+};
+use aws_smithy_types::checksum_config::RequestChecksumCalculation::WhenRequired;
+use aws_types::SdkConfig;
+use filetime::{FileTime, set_file_mtime};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time;
+use std::time::SystemTime;
 use tokio::sync::Semaphore;
+use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
 
-use sha2::Digest;
+use sha2::{Digest, Sha256};
+
+use s3sync::Config;
+use s3sync::config::args::parse_from_args;
+use s3sync::pipeline::Pipeline;
+use s3sync::types::SyncStatistics;
+use s3sync::types::token::create_pipeline_cancellation_token;
 
 pub const REGION: &str = "ap-northeast-1";
 pub const EXPRESS_ONE_ZONE_AZ: &str = "apne1-az4";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release 1.57.1 published with a changelog entry update and formatting cleanup.
  * Dependency updated: sha1 bumped from 0.10.6 to 0.11.0.
  * Build environment: builder image switched to rust:1-trixie for a streamlined build.

* **Security**
  * Re-enabled checks for RustSec advisory RUSTSEC-2026-0049 (previous ignore removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->