### PR TITLE
Release v1.58.1: revert Windows /STACK to fix aarch64 LNK1322

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,13 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = [
     "-C", "target-feature=+crt-static",
-    "-C", "link-arg=/STACK:2097152"
+    "-C", "link-arg=/STACK:2000000"
 ]
 
 [target.aarch64-pc-windows-msvc]
 rustflags = [
     "-C", "target-feature=+crt-static",
-    "-C", "link-arg=/STACK:2097152"
+    "-C", "link-arg=/STACK:2000000"
 ]
 
 ## "link-args=-rdynamic" is used to ensure that symbols are exported correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.1] - 2026-04-27
+
+### Fixed
+
+- Reverted Windows `/STACK` size from `2097152` back to `2000000` to work around an `aarch64-pc-windows-msvc` linker failure (`LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)`).
+
 ## [1.58.0] - 2026-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.58.0"
+version = "1.58.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.58.0"
+version = "1.58.1"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."


### PR DESCRIPTION
Restores `/STACK:2000000` for both Windows MSVC targets to work around `LNK1322` (Cortex-A53 hazard) when linking on aarch64-pc-windows-msvc.

## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Suggestions and bug reports are welcome, but responses are not guaranteed.
- Pull requests for new features are generally not accepted, as they may conflict with the design philosophy.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project to be “complete” and will maintain it only minimally going forward.  
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.
