### PR TITLE
Add XXHash64/3/128 and SHA-512 checksum implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /playground
 .idea
+.devcontainer
+.serena

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,13 +1242,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1970,18 +1969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,7 +2237,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2308,12 +2295,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2470,15 +2451,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3212,9 +3184,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.58.6"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2748,6 +2748,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "twox-hash",
  "url",
  "urlencoding",
  "uuid",
@@ -3368,6 +3369,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
@@ -913,11 +913,12 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -976,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -1098,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1225,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1455,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1502,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,7 +1535,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1594,9 +1601,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1624,16 +1631,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1688,12 +1694,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1701,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1714,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1728,15 +1735,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1748,15 +1755,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1786,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1796,12 +1803,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1896,13 +1903,30 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1929,15 +1953,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -1947,21 +1971,21 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -1977,9 +2001,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1998,9 +2022,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2040,7 +2064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2239,18 +2263,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2281,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2308,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2413,9 +2437,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2452,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2579,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2596,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2624,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2650,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2838,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2904,7 +2928,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2926,7 +2950,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3163,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3188,9 +3212,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3239,18 +3263,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3260,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -3378,9 +3402,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -3525,11 +3549,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3538,14 +3562,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3556,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3566,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3579,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3791,9 +3815,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -3806,6 +3830,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3888,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -3909,9 +3939,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3920,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3932,18 +3962,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3952,18 +3982,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3990,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4001,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4012,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.58.6"
+version = "1.59.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."
@@ -60,6 +60,7 @@ tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full"] }
 tokio-util = "0.7.18"
+twox-hash = { version = "2.1.2", default-features = false, features = ["std", "xxhash64", "xxhash3_64", "xxhash3_128"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json", "local-time"] }
 url = "2.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.89"
 async-channel = "2.5.0"
 aws-config = { version = "1.8.16", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
 aws-runtime = "1.7.3"
-aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { version = "1.132.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 aws-smithy-runtime-api = "1.12.0"
 aws-smithy-types = { version = "1.4.7" }
 aws-smithy-types-convert = { version = "0.60.14", features = ["convert-chrono"] }
@@ -29,7 +29,7 @@ base64 = "0.22.1"
 byte-unit = "5.2.0"
 cfg-if = "1.0.4"
 clap = { version = "4.6.1", features = ["derive", "env", "cargo", "string"] }
-clap_complete = "4.6.2"
+clap_complete = "4.6.3"
 clap-verbosity-flag = "3.0.4"
 chrono = "0.4.44"
 crc32c = "0.6.8"
@@ -37,7 +37,7 @@ crc32fast = "1.5.0"
 crc-fast = "1.9.0"
 dyn-clone = "1.0.20"
 fancy-regex = "0.18.0"
-filetime = "0.2.27"
+filetime = "0.2.28"
 futures = "0.3.32"
 futures-util = "0.3.32"
 leaky-bucket = "1.1.2"
@@ -48,7 +48,7 @@ http-body-util = "0.1.3"
 hyper = "1.9.0"
 indicatif = "0.18.4"
 log = "0.4.29"
-pin-project = "1.1.11"
+pin-project = "1.1.12"
 percent-encoding = "2.3.2"
 regex = "1.12.3"
 rusty-fork = "0.3.1"
@@ -58,7 +58,7 @@ shadow-rs = { version = "2.0.0", optional = true }
 simple_moving_average = "1.0.2"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = "0.7.18"
 twox-hash = { version = "2.1.2", default-features = false, features = ["std", "xxhash64", "xxhash3_64", "xxhash3_128"] }
 tracing = "0.1.44"

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -1395,7 +1395,13 @@ impl CLIArgs {
         }
 
         if let Some(additional_checksum_algorithm) = &self.additional_checksum_algorithm {
-            if additional_checksum_algorithm == "SHA1" || additional_checksum_algorithm == "SHA256"
+            if additional_checksum_algorithm == "SHA1"
+                || additional_checksum_algorithm == "SHA256"
+                || additional_checksum_algorithm == "SHA512"
+                || additional_checksum_algorithm == "XXHASH128"
+                || additional_checksum_algorithm == "XXHASH3"
+                || additional_checksum_algorithm == "XXHASH64"
+                || additional_checksum_algorithm == "MD5"
             {
                 return Err(FULL_OBJECT_CHECKSUM_NOT_SUPPORTED.to_string());
             }

--- a/src/config/args/value_parser/checksum_algorithm.rs
+++ b/src/config/args/value_parser/checksum_algorithm.rs
@@ -1,6 +1,6 @@
 use aws_sdk_s3::types::ChecksumAlgorithm;
 
-const INVALID_CHECKSUM_ALGORITHM: &str = "invalid checksum_algorithm. valid choices: CRC32 | CRC32C | CRC64NVME | SHA1 | SHA256 | SHA512 | XXHASH128 | XXHASH3 | XXHASH64 .";
+const INVALID_CHECKSUM_ALGORITHM: &str = "invalid checksum_algorithm. valid choices: CRC32 | CRC32C | CRC64NVME | MD5 | SHA1 | SHA256 | SHA512 | XXHASH128 | XXHASH3 | XXHASH64 .";
 
 pub fn parse_checksum_algorithm(checksum_algorithm: &str) -> Result<String, String> {
     #[allow(deprecated)]

--- a/src/config/args/value_parser/checksum_algorithm.rs
+++ b/src/config/args/value_parser/checksum_algorithm.rs
@@ -1,7 +1,6 @@
 use aws_sdk_s3::types::ChecksumAlgorithm;
 
-const INVALID_CHECKSUM_ALGORITHM: &str =
-    "invalid checksum_algorithm. valid choices: CRC32 | CRC32C | CRC64NVME | SHA1 | SHA256 .";
+const INVALID_CHECKSUM_ALGORITHM: &str = "invalid checksum_algorithm. valid choices: CRC32 | CRC32C | CRC64NVME | SHA1 | SHA256 | SHA512 | XXHASH128 | XXHASH3 | XXHASH64 .";
 
 pub fn parse_checksum_algorithm(checksum_algorithm: &str) -> Result<String, String> {
     #[allow(deprecated)]

--- a/src/storage/checksum/md5.rs
+++ b/src/storage/checksum/md5.rs
@@ -1,0 +1,144 @@
+use base64::{Engine as _, engine::general_purpose};
+
+use crate::storage::checksum::Checksum;
+
+pub struct ChecksumMd5 {
+    hasher: md5::Context,
+    total_hash: Vec<u8>,
+}
+
+const HASH_SIZE_BYTE: usize = 16;
+
+impl Default for ChecksumMd5 {
+    fn default() -> Self {
+        ChecksumMd5 {
+            hasher: md5::Context::new(),
+            total_hash: vec![],
+        }
+    }
+}
+
+impl Checksum for ChecksumMd5 {
+    fn new(_full_object_checksum: bool) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.hasher.consume(data);
+    }
+
+    fn finalize(&mut self) -> String {
+        let digest = self.hasher.clone().finalize();
+        self.total_hash.append(&mut digest.as_slice().to_vec());
+        self.hasher = md5::Context::new();
+        general_purpose::STANDARD.encode(digest.as_slice())
+    }
+
+    fn finalize_all(&mut self) -> String {
+        self.hasher = md5::Context::new();
+        self.hasher.consume(self.total_hash.as_slice());
+
+        let digest = self.hasher.clone().finalize();
+        self.hasher = md5::Context::new();
+        format!(
+            "{}-{}",
+            general_purpose::STANDARD.encode(digest.as_slice()),
+            self.total_hash.len() / HASH_SIZE_BYTE
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::storage::test_helpers::create_large_file;
+
+    const LARGE_FILE_PATH: &str = "./playground/large_data/50MiB";
+    const LARGE_FILE_DIR: &str = "./playground/large_data/";
+    const LARGE_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+    const CHECKSUM_PART_1_TO_3: &str = "g6GGHKcEBCaDJ3oEWdqz1Q==";
+    const CHECKSUM_LAST_PART: &str = "q/S4Q07QcvKbBGJ1nnYBMg==";
+    const CHECKSUM_TOTAL: &str = "6E0aXvH2r9sNLDByrfX7pQ==-4";
+
+    #[tokio::test]
+    async fn checksum_md5_test() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumMd5::default();
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    #[tokio::test]
+    async fn checksum_md5_test_with_new() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumMd5::new(true);
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    fn init_dummy_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("dummy=trace")
+            .try_init();
+    }
+}

--- a/src/storage/checksum/mod.rs
+++ b/src/storage/checksum/mod.rs
@@ -11,6 +11,10 @@ pub mod crc32_c;
 pub mod crc64_nvme;
 pub mod sha1;
 pub mod sha256;
+pub mod sha512;
+pub mod xxhash128;
+pub mod xxhash3;
+pub mod xxhash64;
 
 pub trait Checksum {
     fn new(full_object_checksum: bool) -> Self

--- a/src/storage/checksum/mod.rs
+++ b/src/storage/checksum/mod.rs
@@ -3,8 +3,13 @@ use aws_sdk_s3::types::ChecksumAlgorithm;
 use crate::storage::checksum::crc32::ChecksumCRC32;
 use crate::storage::checksum::crc32_c::ChecksumCRC32c;
 use crate::storage::checksum::crc64_nvme::ChecksumCRC64NVMe;
+use crate::storage::checksum::md5::ChecksumMd5;
 use crate::storage::checksum::sha1::ChecksumSha1;
 use crate::storage::checksum::sha256::ChecksumSha256;
+use crate::storage::checksum::sha512::ChecksumSha512;
+use crate::storage::checksum::xxhash3::ChecksumXXHash3;
+use crate::storage::checksum::xxhash64::ChecksumXXHash64;
+use crate::storage::checksum::xxhash128::ChecksumXXHash128;
 
 pub mod crc32;
 pub mod crc32_c;
@@ -47,6 +52,21 @@ impl AdditionalChecksum {
             },
             ChecksumAlgorithm::Crc64Nvme => AdditionalChecksum {
                 checksum: Box::<ChecksumCRC64NVMe>::default(),
+            },
+            ChecksumAlgorithm::Sha512 => AdditionalChecksum {
+                checksum: Box::<ChecksumSha512>::default(),
+            },
+            ChecksumAlgorithm::Xxhash3 => AdditionalChecksum {
+                checksum: Box::<ChecksumXXHash3>::default(),
+            },
+            ChecksumAlgorithm::Xxhash64 => AdditionalChecksum {
+                checksum: Box::<ChecksumXXHash64>::default(),
+            },
+            ChecksumAlgorithm::Xxhash128 => AdditionalChecksum {
+                checksum: Box::<ChecksumXXHash128>::default(),
+            },
+            ChecksumAlgorithm::Md5 => AdditionalChecksum {
+                checksum: Box::<ChecksumMd5>::default(),
             },
             _ => {
                 panic!("Unknown ChecksumAlgorithm")
@@ -95,5 +115,30 @@ mod tests {
     fn crc64nvme_test() {
         AdditionalChecksum::new(ChecksumAlgorithm::Crc64Nvme, false);
         AdditionalChecksum::new(ChecksumAlgorithm::Crc64Nvme, true);
+    }
+
+    #[test]
+    fn sha512_test() {
+        AdditionalChecksum::new(ChecksumAlgorithm::Sha512, false);
+    }
+
+    #[test]
+    fn xxhash3_test() {
+        AdditionalChecksum::new(ChecksumAlgorithm::Xxhash3, false);
+    }
+
+    #[test]
+    fn xxhash64_test() {
+        AdditionalChecksum::new(ChecksumAlgorithm::Xxhash64, false);
+    }
+
+    #[test]
+    fn xxhash128_test() {
+        AdditionalChecksum::new(ChecksumAlgorithm::Xxhash128, false);
+    }
+
+    #[test]
+    fn md5_test() {
+        AdditionalChecksum::new(ChecksumAlgorithm::Md5, false);
     }
 }

--- a/src/storage/checksum/mod.rs
+++ b/src/storage/checksum/mod.rs
@@ -9,6 +9,7 @@ use crate::storage::checksum::sha256::ChecksumSha256;
 pub mod crc32;
 pub mod crc32_c;
 pub mod crc64_nvme;
+pub mod md5;
 pub mod sha1;
 pub mod sha256;
 pub mod sha512;

--- a/src/storage/checksum/sha512.rs
+++ b/src/storage/checksum/sha512.rs
@@ -1,0 +1,151 @@
+use base64::{Engine as _, engine::general_purpose};
+use sha2;
+use sha2::Digest;
+
+use crate::storage::checksum::Checksum;
+
+pub struct ChecksumSha512 {
+    hasher: sha2::Sha512,
+    total_hash: Vec<u8>,
+}
+
+const HASH_SIZE_BYTE: usize = 64;
+
+impl Default for ChecksumSha512 {
+    fn default() -> Self {
+        ChecksumSha512 {
+            hasher: sha2::Sha512::new(),
+            total_hash: vec![],
+        }
+    }
+}
+
+// sha2 uses generic-array v0.x internally, which is deprecated.
+// Suppress warnings until the underlying library is updated.
+#[allow(deprecated)]
+impl Checksum for ChecksumSha512 {
+    fn new(_full_object_checksum: bool) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.hasher.update(data);
+    }
+
+    fn finalize(&mut self) -> String {
+        let digest = self.hasher.clone().finalize();
+        self.total_hash.append(&mut digest.to_vec());
+        self.hasher.reset();
+        general_purpose::STANDARD.encode(digest.as_slice())
+    }
+
+    fn finalize_all(&mut self) -> String {
+        self.hasher.reset();
+        self.hasher.update(self.total_hash.as_slice());
+
+        let digest = self.hasher.clone().finalize();
+        self.hasher.reset();
+        format!(
+            "{}-{}",
+            general_purpose::STANDARD.encode(digest.as_slice()),
+            self.total_hash.len() / HASH_SIZE_BYTE
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::storage::test_helpers::create_large_file;
+
+    const LARGE_FILE_PATH: &str = "./playground/large_data/50MiB";
+    const LARGE_FILE_DIR: &str = "./playground/large_data/";
+    const LARGE_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+    const CHECKSUM_PART_1_TO_3: &str =
+        "007C5Od555bSYB4tw0iayLg/OBJfOV0BVh4qwLZtdVkIy1+vezx+LIELM83SCl7nISkzbXe5yrbve6Ull+paqA==";
+    const CHECKSUM_LAST_PART: &str =
+        "5CcjjEfTOfVWYGi6pTk0lcB437YtnBQe17kEiXlfG+6nsc+TcUS8L+41sxSsWw7Vo3ArkCIL2n4sPqbvaqF1/g==";
+    const CHECKSUM_TOTAL: &str = "5qRYilX4F5jQqYoodGngocR+JSTI/8/r90eTYCrWH4sd6gfRDkLlxMAitTbkbzFoJL7Q8xg+Sk5Z4XVumthJ4Q==-4";
+
+    #[tokio::test]
+    async fn checksum_sha512_test() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumSha512::default();
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    #[tokio::test]
+    async fn checksum_sha512_test_with_new() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumSha512::new(true);
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    fn init_dummy_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("dummy=trace")
+            .try_init();
+    }
+}

--- a/src/storage/checksum/xxhash128.rs
+++ b/src/storage/checksum/xxhash128.rs
@@ -1,0 +1,145 @@
+use base64::{Engine as _, engine::general_purpose};
+use twox_hash::XxHash3_128;
+
+use crate::storage::checksum::Checksum;
+
+pub struct ChecksumXXHash128 {
+    hasher: XxHash3_128,
+    total_hash: Vec<u8>,
+}
+
+const HASH_SIZE_BYTE: usize = 16;
+
+impl Default for ChecksumXXHash128 {
+    fn default() -> Self {
+        ChecksumXXHash128 {
+            hasher: XxHash3_128::new(),
+            total_hash: vec![],
+        }
+    }
+}
+
+impl Checksum for ChecksumXXHash128 {
+    fn new(_full_object_checksum: bool) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.hasher.write(data);
+    }
+
+    fn finalize(&mut self) -> String {
+        let digest = self.hasher.finish_128().to_be_bytes();
+        self.total_hash.append(&mut digest.to_vec());
+        self.hasher = XxHash3_128::new();
+        general_purpose::STANDARD.encode(digest.as_slice())
+    }
+
+    fn finalize_all(&mut self) -> String {
+        self.hasher = XxHash3_128::new();
+        self.hasher.write(self.total_hash.as_slice());
+
+        let digest = self.hasher.finish_128().to_be_bytes();
+        self.hasher = XxHash3_128::new();
+        format!(
+            "{}-{}",
+            general_purpose::STANDARD.encode(digest.as_slice()),
+            self.total_hash.len() / HASH_SIZE_BYTE
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::storage::test_helpers::create_large_file;
+
+    const LARGE_FILE_PATH: &str = "./playground/large_data/50MiB";
+    const LARGE_FILE_DIR: &str = "./playground/large_data/";
+    const LARGE_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+    const CHECKSUM_PART_1_TO_3: &str = "Gwie9Py7sCeDQ07X8+KXyg==";
+    const CHECKSUM_LAST_PART: &str = "kldruRZheXEpszNNUgu3Ig==";
+    const CHECKSUM_TOTAL: &str = "PK2GU0HrD3pAIrdyVEfmbQ==-4";
+
+    #[tokio::test]
+    async fn checksum_xxhash128_test() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash128::default();
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    #[tokio::test]
+    async fn checksum_xxhash128_test_with_new() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash128::new(true);
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    fn init_dummy_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("dummy=trace")
+            .try_init();
+    }
+}

--- a/src/storage/checksum/xxhash3.rs
+++ b/src/storage/checksum/xxhash3.rs
@@ -1,0 +1,146 @@
+use base64::{Engine as _, engine::general_purpose};
+use std::hash::Hasher as _;
+use twox_hash::XxHash3_64;
+
+use crate::storage::checksum::Checksum;
+
+pub struct ChecksumXXHash3 {
+    hasher: XxHash3_64,
+    total_hash: Vec<u8>,
+}
+
+const HASH_SIZE_BYTE: usize = 8;
+
+impl Default for ChecksumXXHash3 {
+    fn default() -> Self {
+        ChecksumXXHash3 {
+            hasher: XxHash3_64::new(),
+            total_hash: vec![],
+        }
+    }
+}
+
+impl Checksum for ChecksumXXHash3 {
+    fn new(_full_object_checksum: bool) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.hasher.write(data);
+    }
+
+    fn finalize(&mut self) -> String {
+        let digest = self.hasher.finish().to_be_bytes();
+        self.total_hash.append(&mut digest.to_vec());
+        self.hasher = XxHash3_64::new();
+        general_purpose::STANDARD.encode(digest.as_slice())
+    }
+
+    fn finalize_all(&mut self) -> String {
+        self.hasher = XxHash3_64::new();
+        self.hasher.write(self.total_hash.as_slice());
+
+        let digest = self.hasher.finish().to_be_bytes();
+        self.hasher = XxHash3_64::new();
+        format!(
+            "{}-{}",
+            general_purpose::STANDARD.encode(digest.as_slice()),
+            self.total_hash.len() / HASH_SIZE_BYTE
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::storage::test_helpers::create_large_file;
+
+    const LARGE_FILE_PATH: &str = "./playground/large_data/50MiB";
+    const LARGE_FILE_DIR: &str = "./playground/large_data/";
+    const LARGE_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+    const CHECKSUM_PART_1_TO_3: &str = "g0NO1/Pil8o=";
+    const CHECKSUM_LAST_PART: &str = "KbMzTVILtyI=";
+    const CHECKSUM_TOTAL: &str = "UP876eHGiuo=-4";
+
+    #[tokio::test]
+    async fn checksum_xxhash3_test() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash3::default();
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    #[tokio::test]
+    async fn checksum_xxhash3_test_with_new() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash3::new(true);
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    fn init_dummy_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("dummy=trace")
+            .try_init();
+    }
+}

--- a/src/storage/checksum/xxhash64.rs
+++ b/src/storage/checksum/xxhash64.rs
@@ -1,0 +1,146 @@
+use base64::{Engine as _, engine::general_purpose};
+use std::hash::Hasher as _;
+use twox_hash::XxHash64;
+
+use crate::storage::checksum::Checksum;
+
+pub struct ChecksumXXHash64 {
+    hasher: XxHash64,
+    total_hash: Vec<u8>,
+}
+
+const HASH_SIZE_BYTE: usize = 8;
+
+impl Default for ChecksumXXHash64 {
+    fn default() -> Self {
+        ChecksumXXHash64 {
+            hasher: XxHash64::with_seed(0),
+            total_hash: vec![],
+        }
+    }
+}
+
+impl Checksum for ChecksumXXHash64 {
+    fn new(_full_object_checksum: bool) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.hasher.write(data);
+    }
+
+    fn finalize(&mut self) -> String {
+        let digest = self.hasher.finish().to_be_bytes();
+        self.total_hash.append(&mut digest.to_vec());
+        self.hasher = XxHash64::with_seed(0);
+        general_purpose::STANDARD.encode(digest.as_slice())
+    }
+
+    fn finalize_all(&mut self) -> String {
+        self.hasher = XxHash64::with_seed(0);
+        self.hasher.write(self.total_hash.as_slice());
+
+        let digest = self.hasher.finish().to_be_bytes();
+        self.hasher = XxHash64::with_seed(0);
+        format!(
+            "{}-{}",
+            general_purpose::STANDARD.encode(digest.as_slice()),
+            self.total_hash.len() / HASH_SIZE_BYTE
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::storage::test_helpers::create_large_file;
+
+    const LARGE_FILE_PATH: &str = "./playground/large_data/50MiB";
+    const LARGE_FILE_DIR: &str = "./playground/large_data/";
+    const LARGE_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+    const CHECKSUM_PART_1_TO_3: &str = "q6TmMlqFqls=";
+    const CHECKSUM_LAST_PART: &str = "SVdoea44HMY=";
+    const CHECKSUM_TOTAL: &str = "ivM+ESXvuqM=-4";
+
+    #[tokio::test]
+    async fn checksum_xxhash64_test() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash64::default();
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    #[tokio::test]
+    async fn checksum_xxhash64_test_with_new() {
+        init_dummy_tracing_subscriber();
+
+        create_large_file(LARGE_FILE_PATH, LARGE_FILE_DIR, LARGE_FILE_SIZE).await;
+        let mut file = File::open(LARGE_FILE_PATH).await.unwrap();
+
+        let mut checksum = ChecksumXXHash64::new(true);
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(17179870);
+        buffer.resize_with(17179870, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_PART_1_TO_3.to_string());
+
+        let mut buffer = Vec::<u8>::with_capacity(889190);
+        buffer.resize_with(889190, Default::default);
+        file.read_exact(buffer.as_mut_slice()).await.unwrap();
+        checksum.update(buffer.as_slice());
+        assert_eq!(checksum.finalize(), CHECKSUM_LAST_PART.to_string());
+
+        assert_eq!(checksum.finalize_all(), CHECKSUM_TOTAL.to_string());
+    }
+
+    fn init_dummy_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("dummy=trace")
+            .try_init();
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -392,6 +392,21 @@ pub fn get_additional_checksum(
         ChecksumAlgorithm::Crc64Nvme => get_object_output
             .checksum_crc64_nvme()
             .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Sha512 => get_object_output
+            .checksum_sha512()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash3 => get_object_output
+            .checksum_xxhash3()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash64 => get_object_output
+            .checksum_xxhash64()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash128 => get_object_output
+            .checksum_xxhash128()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Md5 => get_object_output
+            .checksum_md5()
+            .map(|checksum| checksum.to_string()),
         _ => {
             panic!("unknown algorithm")
         }
@@ -419,6 +434,21 @@ pub fn get_additional_checksum_with_head_object(
             .map(|checksum| checksum.to_string()),
         ChecksumAlgorithm::Crc64Nvme => head_object_output
             .checksum_crc64_nvme()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Sha512 => head_object_output
+            .checksum_sha512()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash3 => head_object_output
+            .checksum_xxhash3()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash64 => head_object_output
+            .checksum_xxhash64()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Xxhash128 => head_object_output
+            .checksum_xxhash128()
+            .map(|checksum| checksum.to_string()),
+        ChecksumAlgorithm::Md5 => head_object_output
+            .checksum_md5()
             .map(|checksum| checksum.to_string()),
         _ => {
             panic!("unknown algorithm")


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Suggestions and bug reports are welcome, but responses are not guaranteed.
- Pull requests for new features are generally not accepted, as they may conflict with the design philosophy.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project to be “complete” and will maintain it only minimally going forward.  
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SHA-512, MD5, and XXHash family checksum options (XXHash128, XXHash3, XXHash64) for additional integrity methods
  * Supported those algorithms when retrieving object checksum metadata

* **Chores**
  * Version bumped to 1.59.0
  * Added twox-hash dependency
  * Updated ignore list to skip local/editor/devcontainer metadata files

* **Bug Fixes / Improvements**
  * Expanded validation/error text and conflict detection for checksum option selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->