### PR TITLE
Add error checks for unsupported checksum algorithms in AWS SDK for Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.7] - 2026-05-17
+
+### Changed
+
+- AWS SDK for Rust does not support the new checksums XXHash64/3/128, MD5, and SHA-512, so an error check has been added
+  to prevent these from being specified as additional checksums. We plan to remove this restriction when AWS SDK for
+  Rust supports these new chucksums.
+
 ## [1.58.6] - 2026-04-28
 
 ### Changed
 
-- Removed `aarch64-pc-windows-msvc` (`windows-11-arm`) from CI build/test matrix while the release artifact for that target stays suspended.
+- Removed `aarch64-pc-windows-msvc` (`windows-11-arm`) from CI build/test matrix while the release artifact for that
+  target stays suspended.
 
 ## [1.58.5] - 2026-04-28
 
 ### Changed
 
-- Suspended `windows-aarch64` (`aarch64-pc-windows-msvc`) release artifact: `link.exe` keeps failing with `LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)` and the workarounds tried in 1.58.1–1.58.3 have not stabilised the build. Pre-built binaries for this target will resume once a reliable fix is in place.
-- Switched the `aarch64-pc-windows-msvc` target to `lto = "thin"` with `codegen-units = 16` via target-specific `rustflags` (no longer release-blocking, but kept to make local/CI builds for that target succeed).
+- Suspended `windows-aarch64` (`aarch64-pc-windows-msvc`) release artifact: `link.exe` keeps failing with
+  `LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)` and the workarounds tried in
+  1.58.1–1.58.3 have not stabilised the build. Pre-built binaries for this target will resume once a reliable fix is in
+  place.
+- Switched the `aarch64-pc-windows-msvc` target to `lto = "thin"` with `codegen-units = 16` via target-specific
+  `rustflags` (no longer release-blocking, but kept to make local/CI builds for that target succeed).
 
 ## [1.58.2] - 2026-04-27
 
 ### Changed
 
-- Added `/OPT:REF` and `/OPT:ICF` linker flags for `aarch64-pc-windows-msvc` to reduce binary size via dead code/data elimination and identical COMDAT folding.
+- Added `/OPT:REF` and `/OPT:ICF` linker flags for `aarch64-pc-windows-msvc` to reduce binary size via dead code/data
+  elimination and identical COMDAT folding.
 
 ## [1.58.1] - 2026-04-27
 
 ### Fixed
 
-- Reverted Windows `/STACK` size from `2097152` back to `2000000` to work around an `aarch64-pc-windows-msvc` linker failure (`LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)`).
+- Reverted Windows `/STACK` size from `2097152` back to `2000000` to work around an `aarch64-pc-windows-msvc` linker
+  failure (`LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)`).
 
 ## [1.58.0] - 2026-04-27
 
@@ -39,7 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21 (vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls 0.23 via `aws-smithy-http-client`, is re-enabled explicitly.
+- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21 (
+  vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls
+  0.23 via `aws-smithy-http-client`, is re-enabled explicitly.
 
 ### Changed
 
@@ -52,7 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early (e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing newline no longer unwraps the write/flush result.
+- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early (
+  e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing
+  newline no longer unwraps the write/flush result.
 
 ## [1.57.1] - 2026-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AWS SDK for Rust does not support the new checksums XXHash64/3/128, MD5, and SHA-512, so an error check has been added
   to prevent these from being specified as additional checksums. We plan to remove this restriction when AWS SDK for
-  Rust supports these new chucksums.
+  Rust supports these new checksums.
 
 ## [1.58.6] - 2026-04-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.58.6"
+version = "1.58.7"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.58.6"
+version = "1.58.7"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -1,9 +1,23 @@
 # s3sync
 
+[![Crates.io](https://img.shields.io/crates/v/s3sync.svg)](https://crates.io/crates/s3sync)
+[![Crates.io](https://img.shields.io/crates/d/s3sync?label=downloads%20%28crates.io%29)](https://crates.io/crates/s3sync)
+[![GitHub](https://img.shields.io/github/downloads/nidor1998/s3sync/total?label=downloads%20%28GitHub%29)](https://github.com/nidor1998/s3sync/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+![MSRV](https://img.shields.io/badge/msrv-1.91.1-red)
+![CI](https://github.com/nidor1998/s3sync/actions/workflows/ci.yml/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/nidor1998/s3sync/branch/main/graph/badge.svg?token=GO3DGS2BR4)](https://codecov.io/gh/nidor1998/s3sync)
 
-> **Note on issues:** This project continues to be maintained, and binaries will keep being released. However, to consolidate discussion across the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs) family, **please file new issues in the [s7cmd](https://github.com/nidor1998/s7cmd) repository** instead of here. [s7cmd](https://github.com/nidor1998/s7cmd) bundles these tools as subcommands built on the same underlying code, so its behavior matches the standalone binaries and it can be used in their place. **Before opening an issue, please read the Scope and Non-Goals sections in the READMEs of [s7cmd](https://github.com/nidor1998/s7cmd) and each project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))** — requests outside the documented scope will generally be declined. Existing issues in this repository will continue to be handled as usual.
+> **Note on issues:** This project continues to be maintained, and binaries will keep being released. However, to
+> consolidate discussion across
+> the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs)
+> family, **please file new issues in the [s7cmd](https://github.com/nidor1998/s7cmd) repository** instead of
+> here. [s7cmd](https://github.com/nidor1998/s7cmd) bundles these tools as subcommands built on the same underlying code,
+> so its behavior matches the standalone binaries and it can be used in their place. **Before opening an issue, please
+> read the Scope and Non-Goals sections in the READMEs of [s7cmd](https://github.com/nidor1998/s7cmd) and each
+> project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))
+** — requests outside the documented scope will generally be declined. Existing issues in this repository will continue
+> to be handled as usual.
 
 ## Table of contents
 
@@ -11,8 +25,6 @@
 <summary>Click to expand to view table of contents </summary>
 
 - [Overview](#Overview)
-    * [Scope](#Scope)
-    * [Non-Goals](#Non-Goals)
 - [Features](#Features)
     * [Object integrity check](#Object-Integrity-Check)
     * [Multiple ways](#Multiple-Ways)
@@ -104,6 +116,9 @@
     * [-h/--help](#-h--help)
 
 - [All command line options](#All-command-line-options)
+- [Scope](#Scope)
+- [Non-Goals](#Non-Goals)
+- [Contributing](#Contributing)
 
 </details>
 
@@ -126,24 +141,6 @@ This demo shows the integrity check features (MD5 and SHA256) and performance (4
 The final command performs an incremental transfer based on modification time, enabling fast incremental transfers.
 
 ![demo](media/demo.webp)
-
-### Scope
-
-s3sync targets **Amazon S3** as its only supported platform. S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided strictly **as-is**, with **absolutely no support or assistance**. Such services may work via `--target-endpoint-url` / `--source-endpoint-url` (and `--source-force-path-style` / `--target-force-path-style` when path-style addressing is required), but they are not part of the official test matrix and behavior may change between releases. This is a structural consequence of building on `aws-sdk-rust`, which is generated from AWS service models and assumes Amazon S3 semantics (checksum headers, endpoint resolution, signing variants, response schemas); features that depend on AWS-specific semantics, such as CRC64NVME checksums or newer S3 API additions, may not work against non-AWS endpoints. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
-
-s3sync is a synchronization tool with end-to-end integrity verification. It is **not** intended to be a drop-in replacement for, or behaviorally compatible with, any other S3 client — examples include the AWS CLI (`aws s3 sync`, `aws s3 cp`, `aws s3api`), `s5cmd`, `s3cmd`, `rclone`, `mc`, etc. Its command-line flags, sync semantics, output, and exit codes are designed around reliable transfers with verifiable checksums — not interoperability with another tool's interface. Output formats and flag names will not be adjusted to match any external tool, and scripts written against another S3 client should not be expected to work with s3sync unmodified. If you need general S3 management (presign, ACLs, bucket policies, lifecycle, etc.) or compatibility with a specific tool's flag set, use that tool.
-
-### Non-Goals
-
-The following are explicitly out of scope and will not be added, regardless of demand:
-
-- General S3 management operations: bucket creation/deletion, ACLs, bucket policies, lifecycle, replication, inventory, presign, etc. s3sync is a transfer/sync tool; for those operations use the [AWS CLI](https://aws.amazon.com/cli/).
-- Support, testing, or guaranteed compatibility for any storage service other than Amazon S3. S3-compatible storage is provided strictly as-is, with no support or assistance — adding dedicated code paths, provider-specific workarounds, or backends for services such as MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, Tencent COS, Alibaba OSS, Azure Blob Storage, or Google Cloud Storage is out of scope.
-- A graphical interface. s3sync is a CLI/library; UI front-ends are out of scope for this repository.
-- Compatibility with other S3 clients — neither in flag names and behavior, nor in feature coverage. The presence of a feature, flag, or output format in `aws s3`, `s5cmd`, `s3cmd`, `rclone`, `mc`, or any other S3 tool is not, by itself, a reason to add or change it in s3sync. Each request is evaluated only against s3sync's own scope and design principles. Use that other tool if you need its specific surface.
-- A plugin system beyond the existing Lua callbacks and user-defined Rust callbacks.
-
-Issues and pull requests requesting any of the above will be closed.
 
 ## Features
 
@@ -704,7 +701,8 @@ s3sync --source-profile foo --source-region ap-northeast-1 s3://bucket-name1/pre
 s3sync --source-no-sign-request s3://public-bucket-name/prefix /path/to/local
 ```
 
-This issues unsigned requests for the source side, mirroring the AWS CLI's `--no-sign-request`. Conflicts with `--source-profile`, the source access-key flags, and `--source-request-payer`.
+This issues unsigned requests for the source side, mirroring the AWS CLI's `--no-sign-request`. Conflicts with
+`--source-profile`, the source access-key flags, and `--source-request-payer`.
 
 ### Versioning mode
 
@@ -1624,6 +1622,45 @@ assistance**. s3sync has many e2e tests and unit tests that run against Amazon S
 S3-compatible storage is not part of that test matrix and is no longer tested at release time. Because there is no
 official certification for S3-compatible storage and behavior varies across providers, comprehensive testing is not
 possible. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
+
+## Scope
+
+s3sync targets **Amazon S3** as its only supported platform. S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2,
+Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided strictly **as-is**, with **absolutely no
+support or assistance**. Such services may work via `--target-endpoint-url` / `--source-endpoint-url` (and
+`--source-force-path-style` / `--target-force-path-style` when path-style addressing is required), but they are not part
+of the official test matrix and behavior may change between releases. This is a structural consequence of building on
+`aws-sdk-rust`, which is generated from AWS service models and assumes Amazon S3 semantics (checksum headers, endpoint
+resolution, signing variants, response schemas); features that depend on AWS-specific semantics, such as CRC64NVME
+checksums or newer S3 API additions, may not work against non-AWS endpoints. Bug reports, questions, and assistance
+requests regarding S3-compatible storage will not be addressed.
+
+s3sync is a synchronization tool with end-to-end integrity verification. It is **not** intended to be a drop-in
+replacement for, or behaviorally compatible with, any other S3 client — examples include the AWS CLI (`aws s3 sync`,
+`aws s3 cp`, `aws s3api`), `s5cmd`, `s3cmd`, `rclone`, `mc`, etc. Its command-line flags, sync semantics, output, and
+exit codes are designed around reliable transfers with verifiable checksums — not interoperability with another tool's
+interface. Output formats and flag names will not be adjusted to match any external tool, and scripts written against
+another S3 client should not be expected to work with s3sync unmodified. If you need general S3 management (presign,
+ACLs, bucket policies, lifecycle, etc.) or compatibility with a specific tool's flag set, use that tool.
+
+## Non-Goals
+
+The following are explicitly out of scope and will not be added, regardless of demand:
+
+- General S3 management operations: bucket creation/deletion, ACLs, bucket policies, lifecycle, replication, inventory,
+  presign, etc. s3sync is a transfer/sync tool; for those operations use the [AWS CLI](https://aws.amazon.com/cli/).
+- Support, testing, or guaranteed compatibility for any storage service other than Amazon S3. S3-compatible storage is
+  provided strictly as-is, with no support or assistance — adding dedicated code paths, provider-specific workarounds,
+  or backends for services such as MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS,
+  Tencent COS, Alibaba OSS, Azure Blob Storage, or Google Cloud Storage is out of scope.
+- A graphical interface. s3sync is a CLI/library; UI front-ends are out of scope for this repository.
+- Compatibility with other S3 clients — neither in flag names and behavior, nor in feature coverage. The presence of a
+  feature, flag, or output format in `aws s3`, `s5cmd`, `s3cmd`, `rclone`, `mc`, or any other S3 tool is not, by itself,
+  a reason to add or change it in s3sync. Each request is evaluated only against s3sync's own scope and design
+  principles. Use that other tool if you need its specific surface.
+- A plugin system beyond the existing Lua callbacks and user-defined Rust callbacks.
+
+Issues and pull requests requesting any of the above will be closed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # s3sync
 
+[![Crates.io](https://img.shields.io/crates/v/s3sync.svg)](https://crates.io/crates/s3sync)
+[![Crates.io](https://img.shields.io/crates/d/s3sync?label=downloads%20%28crates.io%29)](https://crates.io/crates/s3sync)
+[![GitHub](https://img.shields.io/github/downloads/nidor1998/s3sync/total?label=downloads%20%28GitHub%29)](https://github.com/nidor1998/s3sync/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+![MSRV](https://img.shields.io/badge/msrv-1.91.1-red)
+![CI](https://github.com/nidor1998/s3sync/actions/workflows/ci.yml/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/nidor1998/s3sync/branch/main/graph/badge.svg?token=GO3DGS2BR4)](https://codecov.io/gh/nidor1998/s3sync)
 
-> **Note on issues:** This project continues to be maintained, and binaries will keep being released. However, to consolidate discussion across the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs) family, **please file new issues in the [s7cmd](https://github.com/nidor1998/s7cmd) repository** instead of here. [s7cmd](https://github.com/nidor1998/s7cmd) bundles these tools as subcommands built on the same underlying code, so its behavior matches the standalone binaries and it can be used in their place. **Before opening an issue, please read the Scope and Non-Goals sections in the READMEs of [s7cmd](https://github.com/nidor1998/s7cmd) and each project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))** — requests outside the documented scope will generally be declined. Existing issues in this repository will continue to be handled as usual.
+> **Note on issues:** This project continues to be maintained, and binaries will keep being released. However, to
+> consolidate discussion across
+> the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs)
+> family, **please file new issues in the [s7cmd](https://github.com/nidor1998/s7cmd) repository** instead of
+> here. [s7cmd](https://github.com/nidor1998/s7cmd) bundles these tools as subcommands built on the same underlying code,
+> so its behavior matches the standalone binaries and it can be used in their place. **Before opening an issue, please
+> read the Scope and Non-Goals sections in the READMEs of [s7cmd](https://github.com/nidor1998/s7cmd) and each
+> project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))
+** — requests outside the documented scope will generally be declined. Existing issues in this repository will continue
+> to be handled as usual.
 
 ## Overview
 
@@ -22,24 +36,6 @@ This demo shows the integrity check features (MD5 and SHA256) and performance (4
 The final command performs an incremental transfer based on modification time, enabling fast incremental transfers.
 
 ![demo](media/demo.webp)
-
-### Scope
-
-s3sync targets **Amazon S3** as its only supported platform. S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided strictly **as-is**, with **absolutely no support or assistance**. Such services may work via `--target-endpoint-url` / `--source-endpoint-url` (and `--source-force-path-style` / `--target-force-path-style` when path-style addressing is required), but they are not part of the official test matrix and behavior may change between releases. This is a structural consequence of building on `aws-sdk-rust`, which is generated from AWS service models and assumes Amazon S3 semantics (checksum headers, endpoint resolution, signing variants, response schemas); features that depend on AWS-specific semantics, such as CRC64NVME checksums or newer S3 API additions, may not work against non-AWS endpoints. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
-
-s3sync is a synchronization tool with end-to-end integrity verification. It is **not** intended to be a drop-in replacement for, or behaviorally compatible with, any other S3 client — examples include the AWS CLI (`aws s3 sync`, `aws s3 cp`, `aws s3api`), `s5cmd`, `s3cmd`, `rclone`, `mc`, etc. Its command-line flags, sync semantics, output, and exit codes are designed around reliable transfers with verifiable checksums — not interoperability with another tool's interface. Output formats and flag names will not be adjusted to match any external tool, and scripts written against another S3 client should not be expected to work with s3sync unmodified. If you need general S3 management (presign, ACLs, bucket policies, lifecycle, etc.) or compatibility with a specific tool's flag set, use that tool.
-
-### Non-Goals
-
-The following are explicitly out of scope and will not be added, regardless of demand:
-
-- General S3 management operations: bucket creation/deletion, ACLs, bucket policies, lifecycle, replication, inventory, presign, etc. s3sync is a transfer/sync tool; for those operations use the [AWS CLI](https://aws.amazon.com/cli/).
-- Support, testing, or guaranteed compatibility for any storage service other than Amazon S3. S3-compatible storage is provided strictly as-is, with no support or assistance — adding dedicated code paths, provider-specific workarounds, or backends for services such as MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, Tencent COS, Alibaba OSS, Azure Blob Storage, or Google Cloud Storage is out of scope.
-- A graphical interface. s3sync is a CLI/library; UI front-ends are out of scope for this repository.
-- Compatibility with other S3 clients — neither in flag names and behavior, nor in feature coverage. The presence of a feature, flag, or output format in `aws s3`, `s5cmd`, `s3cmd`, `rclone`, `mc`, or any other S3 tool is not, by itself, a reason to add or change it in s3sync. Each request is evaluated only against s3sync's own scope and design principles. Use that other tool if you need its specific surface.
-- A plugin system beyond the existing Lua callbacks and user-defined Rust callbacks.
-
-Issues and pull requests requesting any of the above will be closed.
 
 ## Who is this for?
 
@@ -262,6 +258,45 @@ possible. Bug reports, questions, and assistance requests regarding S3-compatibl
 ## More information
 
 For more information, please refer to the [full README](https://github.com/nidor1998/s3sync/blob/main/FULL_README.md)
+
+### Scope
+
+s3sync targets **Amazon S3** as its only supported platform. S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2,
+Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided strictly **as-is**, with **absolutely no
+support or assistance**. Such services may work via `--target-endpoint-url` / `--source-endpoint-url` (and
+`--source-force-path-style` / `--target-force-path-style` when path-style addressing is required), but they are not part
+of the official test matrix and behavior may change between releases. This is a structural consequence of building on
+`aws-sdk-rust`, which is generated from AWS service models and assumes Amazon S3 semantics (checksum headers, endpoint
+resolution, signing variants, response schemas); features that depend on AWS-specific semantics, such as CRC64NVME
+checksums or newer S3 API additions, may not work against non-AWS endpoints. Bug reports, questions, and assistance
+requests regarding S3-compatible storage will not be addressed.
+
+s3sync is a synchronization tool with end-to-end integrity verification. It is **not** intended to be a drop-in
+replacement for, or behaviorally compatible with, any other S3 client — examples include the AWS CLI (`aws s3 sync`,
+`aws s3 cp`, `aws s3api`), `s5cmd`, `s3cmd`, `rclone`, `mc`, etc. Its command-line flags, sync semantics, output, and
+exit codes are designed around reliable transfers with verifiable checksums — not interoperability with another tool's
+interface. Output formats and flag names will not be adjusted to match any external tool, and scripts written against
+another S3 client should not be expected to work with s3sync unmodified. If you need general S3 management (presign,
+ACLs, bucket policies, lifecycle, etc.) or compatibility with a specific tool's flag set, use that tool.
+
+### Non-Goals
+
+The following are explicitly out of scope and will not be added, regardless of demand:
+
+- General S3 management operations: bucket creation/deletion, ACLs, bucket policies, lifecycle, replication, inventory,
+  presign, etc. s3sync is a transfer/sync tool; for those operations use the [AWS CLI](https://aws.amazon.com/cli/).
+- Support, testing, or guaranteed compatibility for any storage service other than Amazon S3. S3-compatible storage is
+  provided strictly as-is, with no support or assistance — adding dedicated code paths, provider-specific workarounds,
+  or backends for services such as MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS,
+  Tencent COS, Alibaba OSS, Azure Blob Storage, or Google Cloud Storage is out of scope.
+- A graphical interface. s3sync is a CLI/library; UI front-ends are out of scope for this repository.
+- Compatibility with other S3 clients — neither in flag names and behavior, nor in feature coverage. The presence of a
+  feature, flag, or output format in `aws s3`, `s5cmd`, `s3cmd`, `rclone`, `mc`, or any other S3 tool is not, by itself,
+  a reason to add or change it in s3sync. Each request is evaluated only against s3sync's own scope and design
+  principles. Use that other tool if you need its specific surface.
+- A plugin system beyond the existing Lua callbacks and user-defined Rust callbacks.
+
+Issues and pull requests requesting any of the above will be closed.
 
 ## Contributing
 

--- a/src/config/args/tests/options/additional_checksum.rs
+++ b/src/config/args/tests/options/additional_checksum.rs
@@ -67,6 +67,110 @@ mod tests {
     }
 
     #[test]
+    fn with_custom_value_with_unsupported_algorithm_md5() {
+        init_dummy_tracing_subscriber();
+
+        let args = vec![
+            "s3sync",
+            "--source-profile",
+            "source_profile",
+            "--target-profile",
+            "target_profile",
+            "--additional-checksum-algorithm",
+            "MD5",
+            "s3://source-bucket/source_key",
+            "s3://target-bucket/target_key",
+        ];
+
+        let config = build_config_from_args(args);
+
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn with_custom_value_with_unsupported_algorithm_xxxhash128() {
+        init_dummy_tracing_subscriber();
+
+        let args = vec![
+            "s3sync",
+            "--source-profile",
+            "source_profile",
+            "--target-profile",
+            "target_profile",
+            "--additional-checksum-algorithm",
+            "XXHASH128",
+            "s3://source-bucket/source_key",
+            "s3://target-bucket/target_key",
+        ];
+
+        let config = build_config_from_args(args);
+
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn with_custom_value_with_unsupported_algorithm_xxxhash3() {
+        init_dummy_tracing_subscriber();
+
+        let args = vec![
+            "s3sync",
+            "--source-profile",
+            "source_profile",
+            "--target-profile",
+            "target_profile",
+            "--additional-checksum-algorithm",
+            "XXHASH3",
+            "s3://source-bucket/source_key",
+            "s3://target-bucket/target_key",
+        ];
+
+        let config = build_config_from_args(args);
+
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn with_custom_value_with_unsupported_algorithm_xxxhash64() {
+        init_dummy_tracing_subscriber();
+
+        let args = vec![
+            "s3sync",
+            "--source-profile",
+            "source_profile",
+            "--target-profile",
+            "target_profile",
+            "--additional-checksum-algorithm",
+            "XXHASH64",
+            "s3://source-bucket/source_key",
+            "s3://target-bucket/target_key",
+        ];
+
+        let config = build_config_from_args(args);
+
+        assert!(config.is_err());
+    }
+    #[test]
+    fn with_custom_value_with_unsupported_algorithm_sha12() {
+        init_dummy_tracing_subscriber();
+
+        let args = vec![
+            "s3sync",
+            "--source-profile",
+            "source_profile",
+            "--target-profile",
+            "target_profile",
+            "--additional-checksum-algorithm",
+            "SHA512",
+            "s3://source-bucket/source_key",
+            "s3://target-bucket/target_key",
+        ];
+
+        let config = build_config_from_args(args);
+
+        assert!(config.is_err());
+    }
+
+    #[test]
     fn with_custom_value_with_conflict() {
         init_dummy_tracing_subscriber();
 

--- a/src/config/args/tests/options/additional_checksum.rs
+++ b/src/config/args/tests/options/additional_checksum.rs
@@ -88,7 +88,7 @@ mod tests {
     }
 
     #[test]
-    fn with_custom_value_with_unsupported_algorithm_xxxhash128() {
+    fn with_custom_value_with_unsupported_algorithm_xxhash128() {
         init_dummy_tracing_subscriber();
 
         let args = vec![
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn with_custom_value_with_unsupported_algorithm_xxxhash3() {
+    fn with_custom_value_with_unsupported_algorithm_xxhash3() {
         init_dummy_tracing_subscriber();
 
         let args = vec![
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn with_custom_value_with_unsupported_algorithm_xxxhash64() {
+    fn with_custom_value_with_unsupported_algorithm_xxhash64() {
         init_dummy_tracing_subscriber();
 
         let args = vec![

--- a/src/config/args/value_parser/checksum_algorithm.rs
+++ b/src/config/args/value_parser/checksum_algorithm.rs
@@ -4,10 +4,13 @@ const INVALID_CHECKSUM_ALGORITHM: &str =
     "invalid checksum_algorithm. valid choices: CRC32 | CRC32C | CRC64NVME | SHA1 | SHA256 .";
 
 pub fn parse_checksum_algorithm(checksum_algorithm: &str) -> Result<String, String> {
-    #[allow(deprecated)]
-    if matches!(
+    if !matches!(
         ChecksumAlgorithm::from(checksum_algorithm),
-        ChecksumAlgorithm::Unknown(_)
+        ChecksumAlgorithm::Crc32
+            | ChecksumAlgorithm::Crc32C
+            | ChecksumAlgorithm::Crc64Nvme
+            | ChecksumAlgorithm::Sha1
+            | ChecksumAlgorithm::Sha256
     ) {
         return Err(INVALID_CHECKSUM_ALGORITHM.to_string());
     }


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Suggestions and bug reports are welcome, but responses are not guaranteed.
- Pull requests for new features are generally not accepted, as they may conflict with the design philosophy.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project to be “complete” and will maintain it only minimally going forward.  
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical security vulnerability in rustls-webpki dependency configuration
  * Resolved "Broken pipe" panic during early consumer termination
  * Added validation to prevent selection of unsupported checksum algorithms (MD5, SHA-512, XXHash64, XXHash3, XXHash128)

* **Documentation**
  * Reorganized and reformatted README for improved structure and readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nidor1998/s3sync/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->