### PR TITLE
Fix/fable 20260718

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .serena
 .devcontainer
+lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stricter validation of S3 path prefixes during argument parsing, including a check for invalid percent-encoded
   characters.
 - Stricter format validation of `--metadata` values (e.g. a leading comma is now rejected).
+- A warning is now reported when a source object's `Expires` value cannot be parsed as an HTTP date; the value falls
+  back to `None` instead of being silently dropped.
+- When downloading to local storage, object verification now runs on the temporary file before it is persisted to the
+  final path, so an object that fails verification never becomes visible at the destination. This also resolves a
+  potential race condition around `set_last_modified`.
+- `--force-retry-count` now applies to object annotation API errors (`ListObjectAnnotations`, `GetObjectAnnotation`,
+  `PutObjectAnnotation`, `DeleteObjectAnnotation`).
 
 ## [1.59.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected `ONE-ZONE_IA` to `ONEZONE_IA` in `--storage-class`/`--annotation-storage-class` options and documentation.
+- Ensured stable object version sorting when multiple versions share the same last-modified second, by falling back to
+  the original `ListObjectVersions` (newest-first) order as a tie-breaker.
+- `--check-etag` with SSE-C now uses the source SSE-C parameters (instead of the target's) when retrieving the source
+  object's ETag.
+- `--force-retry-count` now applies to HeadObject failures.
+- A `DeleteMarker` now reports size `0` and no ETag, instead of panicking.
+- Prevented a panic when an object's `Expiration` contains an invalid `expiry-date`.
+- Stricter validation of S3 path prefixes during argument parsing, including a check for invalid percent-encoded
+  characters.
+- Stricter format validation of `--metadata` values (e.g. a leading comma is now rejected).
+
 ## [1.59.0] - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.59.0"
+version = "1.59.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.59.0"
+version = "1.59.1"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -120,6 +120,7 @@ project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://git
     * [-h/--help](#-h--help)
 
 - [All command line options](#All-command-line-options)
+- [Security assumptions](#Security-assumptions)
 - [Scope](#Scope)
 - [Non-Goals](#Non-Goals)
 - [Contributing](#Contributing)
@@ -1674,7 +1675,7 @@ S3-compatible storage is not part of that test matrix and is no longer tested at
 official certification for S3-compatible storage and behavior varies across providers, comprehensive testing is not
 possible. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
 
-## Security assumption (Trust model)
+## Security assumptions
 
 s3sync is built on a fundamental security assumption: **both the object storage system and the specific bucket you
 synchronize with must be trusted.**

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -404,23 +404,31 @@ CRC64NVME).
 ### Object Annotation support
 
 For S3-to-S3 transfers, s3sync can sync objects along with their object annotations.  
-Use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option to sync objects together with their annotations.  
-s3sync updates only the annotations that have changed.  
+Use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option to sync objects together with their
+annotations.  
+s3sync updates only the annotations that have changed.
 
-Note that copying annotations requires additional API calls.  
+Note that copying annotations requires additional API calls.
 
 Annotations can be synced in parallel (`--max-parallel-uploads`).  
 With the `--server-side-copy` option, Amazon S3 copies the annotations to the target bucket entirely within Amazon S3.  
-However, Amazon S3's `CopyPart` API (used by server-side copy) does not copy the annotations of objects that were multipart-uploaded.  
-So even when `--server-side-copy` is specified, use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option if you need to copy the annotations of multipart-uploaded objects.  
+However, Amazon S3's `CopyPart` API (used by server-side copy) does not copy the annotations of objects that were
+multipart-uploaded.  
+So even when `--server-side-copy` is specified, use the `--enable-sync-object-annotations`/
+`--sync-latest-object-annotations` option if you need to copy the annotations of multipart-uploaded objects.
 
-s3sync verifies an object's annotations against its ETag (MD5 or equivalent) where possible, or against an additional checksum obtained from the source bucket.
+s3sync verifies an object's annotations against its ETag (MD5 or equivalent) where possible, or against an additional
+checksum obtained from the source bucket.
 
-s3sync updates only the annotations that have changed. To detect changes, it compares objects by their ETag where possible; when the ETag cannot be used (for example, when SSE-KMS encryption is enabled), it falls back to the object's Last-Modified timestamp.
+s3sync updates only the annotations that have changed. To detect changes, it compares objects by their ETag where
+possible; when the ETag cannot be used (for example, when SSE-KMS encryption is enabled), it falls back to the object's
+Last-Modified timestamp.
 
-If s3sync fails to create, update, or delete an annotation, the object transfer is treated as a failure; the object itself, however, is not deleted.
+If s3sync fails to create, update, or delete an annotation, the object transfer is treated as a failure; the object
+itself, however, is not deleted.
 
-With `--report-annotations-sync-status`, annotation sync status can be reported even when synchronization is performed by a tool other than s3sync.
+With `--report-annotations-sync-status`, annotation sync status can be reported even when synchronization is performed
+by a tool other than s3sync.
 
 ### Versioning support
 
@@ -509,7 +517,8 @@ The following is an example of the report (the last two lines of the above comma
 
   </details>
 
-You can check the synchronization status of the object's tagging, metadata, annnotation with `--report-metadata-sync-status`,
+You can check the synchronization status of the object's tagging, metadata, annnotation with
+`--report-metadata-sync-status`,
 `--report-tagging-sync-status` and `--report-annotations-sync-status` option.
 
 Note: For reporting, s3sync uses a special process exit code. `0` If all objects are synchronized correctly. `3` If some
@@ -955,14 +964,17 @@ of
 the object.  
 Generally, you should use `--enable-versioning` when you transfer to a new bucket.
 
-s3sync tracks sync state using user-defined metadata. Other tools (such as aws s3 sync or rclone) do not write this metadata and therefore cannot recognize objects already synced by s3sync. As a result, synchronizing the same source and target with another tool may trigger unnecessary transfers, even when the objects are already in sync.
+s3sync tracks sync state using user-defined metadata. Other tools (such as aws s3 sync or rclone) do not write this
+metadata and therefore cannot recognize objects already synced by s3sync. As a result, synchronizing the same source and
+target with another tool may trigger unnecessary transfers, even when the objects are already in sync.
 
 With `--filter-mtime-before` and `--filter-mtime-after` options, you can get snapshots of the objects at a specific
 period.
 
 Intermediate delete markers are not synchronized. Latest version delete markers are synchronized.
 
-Note: in a versioning-enabled bucket, deleting an object means adding a delete marker. The object itself is never actually deleted, but the delete count still increases.
+Note: in a versioning-enabled bucket, deleting an object means adding a delete marker. The object itself is never
+actually deleted, but the delete count still increases.
 
 user-defined metadata: `s3sync_origin_version_id`, `s3sync_origin_last_modified`
 
@@ -1661,6 +1673,33 @@ assistance**. s3sync has many e2e tests and unit tests that run against Amazon S
 S3-compatible storage is not part of that test matrix and is no longer tested at release time. Because there is no
 official certification for S3-compatible storage and behavior varies across providers, comprehensive testing is not
 possible. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
+
+## Security assumption (Trust model)
+
+s3sync is built on a fundamental security assumption: **both the object storage system and the specific bucket you
+synchronize with must be trusted.**
+
+Within this trust model, s3sync implements the security measures you would reasonably expect of a synchronization tool:
+encrypted transport (TLS/HTTPS) for data in transit, end-to-end integrity verification (ETag, MD5, SHA256, and CRC
+checksums), support for server-side encryption, and secure handling of credentials through the standard AWS credential
+providers. These measures protect the confidentiality and integrity of your data against transport-level and accidental
+threats.
+
+However, s3sync assumes that the storage endpoint is honest and non-adversarial — that it correctly implements the S3
+API and returns the data, metadata, and checksum values it actually stores, without tampering. The integrity
+verification features are **not** a defense against a malicious or compromised storage backend that deliberately returns
+falsified data or forged checksums. Against such an adversarial endpoint, these guarantees do not hold.
+
+Crucially, trust must extend to the **bucket**, not just the storage provider. Even when the object storage system
+itself is fully trustworthy, a bucket can still be adversarial — for example, a bucket you do not control, a shared
+bucket writable by others, or one whose objects, metadata, or checksums were crafted by an attacker. If you synchronize
+*from* such a bucket, the data and metadata it serves are already untrusted at the source, and s3sync's guarantees no
+longer apply. A trusted storage provider hosting an untrusted bucket is, for the purposes of this security model, an
+untrusted source.
+
+Synchronizing with an untrusted, compromised, or non-conformant endpoint or bucket is outside s3sync's security model.
+Selecting a trustworthy storage provider, and ensuring that every bucket you synchronize with is one you control or
+trust — including its credentials, encryption, and access policies — remains your responsibility.
 
 ## Scope
 

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -1331,7 +1331,7 @@ Target Options:
           Force path-style addressing for target endpoint [env: TARGET_FORCE_PATH_STYLE=]
       --storage-class <STORAGE_CLASS>
           Type of storage to use for the target object.
-          Valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONE-ZONE_IA | INTELLIGENT_TIERING | GLACIER |
+          Valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER |
                          DEEP_ARCHIVE | GLACIER_IR | EXPRESS_ONEZONE [env: STORAGE_CLASS=]
 
 Filtering:

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -518,7 +518,7 @@ The following is an example of the report (the last two lines of the above comma
 
   </details>
 
-You can check the synchronization status of the object's tagging, metadata, annnotation with
+You can check the synchronization status of the object's tagging, metadata, annotation with
 `--report-metadata-sync-status`,
 `--report-tagging-sync-status` and `--report-annotations-sync-status` option.
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@
 
 > **Note on issues:** This project continues to be maintained, and binaries will keep being released. However, to
 > consolidate discussion across
->　the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs)
+>
+the [s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs)
 > family, **please file new issues in the [s7cmd](https://github.com/nidor1998/s7cmd) repository** instead of
 > here. [s7cmd](https://github.com/nidor1998/s7cmd) bundles these tools as subcommands built on the same underlying
 > code,
 > so its behavior matches the standalone binaries and it can be used in their place. **Before opening an issue, please
 > read the Scope and Non-Goals sections in the READMEs of [s7cmd](https://github.com/nidor1998/s7cmd) and each
-> project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))
+>
+project ([s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) / [s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs))
 ** — requests outside the documented scope will generally be declined. Existing issues in this repository will continue
 > to be handled as usual.
 
@@ -139,20 +141,29 @@ correctly.
 
 - Object Annotation support  
   For S3-to-S3 transfers, s3sync can sync objects along with their object annotations.  
-  Use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option to sync objects together with their annotations.  
+  Use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option to sync objects together with
+  their annotations.
 
-  s3sync updates only the annotations that have changed. To detect changes, it compares objects by their ETag where possible; when the ETag cannot be used (for example, when SSE-KMS encryption is enabled), it falls back to the object's Last-Modified timestamp.  
-  If s3sync fails to create, update, or delete an annotation, the object transfer is treated as a failure; the object itself, however, is not deleted.  
+  s3sync updates only the annotations that have changed. To detect changes, it compares objects by their ETag where
+  possible; when the ETag cannot be used (for example, when SSE-KMS encryption is enabled), it falls back to the
+  object's Last-Modified timestamp.  
+  If s3sync fails to create, update, or delete an annotation, the object transfer is treated as a failure; the object
+  itself, however, is not deleted.
 
-  Note that copying annotations requires additional API calls.  
+  Note that copying annotations requires additional API calls.
 
   Annotations can be synced in parallel (`--max-parallel-uploads`).  
-  With the `--server-side-copy` option, Amazon S3 copies the annotations to the target bucket entirely within Amazon S3.  
-  However, Amazon S3's `CopyPart` API (used by server-side copy) does not copy the annotations of objects that were multipart-uploaded.  
-  So even when `--server-side-copy` is specified, use the `--enable-sync-object-annotations`/`--sync-latest-object-annotations` option if you need to copy the annotations of multipart-uploaded objects.  
-  s3sync verifies an object's annotations against its ETag (MD5 or equivalent) where possible, or against an additional checksum obtained from the source bucket.
+  With the `--server-side-copy` option, Amazon S3 copies the annotations to the target bucket entirely within Amazon
+  S3.  
+  However, Amazon S3's `CopyPart` API (used by server-side copy) does not copy the annotations of objects that were
+  multipart-uploaded.  
+  So even when `--server-side-copy` is specified, use the `--enable-sync-object-annotations`/
+  `--sync-latest-object-annotations` option if you need to copy the annotations of multipart-uploaded objects.  
+  s3sync verifies an object's annotations against its ETag (MD5 or equivalent) where possible, or against an additional
+  checksum obtained from the source bucket.
 
-  With `--report-annotations-sync-status`, annotation sync status can be reported even when synchronization is performed by a tool other than s3sync.
+  With `--report-annotations-sync-status`, annotation sync status can be reported even when synchronization is performed
+  by a tool other than s3sync.
 
 - Sync statistics report  
   s3sync can check and report the synchronization status at any time.  
@@ -217,7 +228,8 @@ correctly.
 
   </details>
 
-  You can check the synchronization status of the object's tagging, metadata, annnotation with `--report-metadata-sync-status`, 
+  You can check the synchronization status of the object's tagging, metadata, annnotation with
+  `--report-metadata-sync-status`,
   `--report-tagging-sync-status` and `--report-annotations-sync-status` option.
 
 - Robust retry logic  
@@ -272,6 +284,33 @@ assistance**. s3sync has many end-to-end and unit tests that run against Amazon 
 S3-compatible storage is not part of that test matrix and is no longer tested at release time. Because there is no
 official certification for S3-compatible storage and behavior varies across providers, comprehensive testing is not
 possible. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
+
+## Security assumption (Trust model)
+
+s3sync is built on a fundamental security assumption: **both the object storage system and the specific bucket you
+synchronize with must be trusted.**
+
+Within this trust model, s3sync implements the security measures you would reasonably expect of a synchronization tool:
+encrypted transport (TLS/HTTPS) for data in transit, end-to-end integrity verification (ETag, MD5, SHA256, and CRC
+checksums), support for server-side encryption, and secure handling of credentials through the standard AWS credential
+providers. These measures protect the confidentiality and integrity of your data against transport-level and accidental
+threats.
+
+However, s3sync assumes that the storage endpoint is honest and non-adversarial — that it correctly implements the S3
+API and returns the data, metadata, and checksum values it actually stores, without tampering. The integrity
+verification features are **not** a defense against a malicious or compromised storage backend that deliberately returns
+falsified data or forged checksums. Against such an adversarial endpoint, these guarantees do not hold.
+
+Crucially, trust must extend to the **bucket**, not just the storage provider. Even when the object storage system
+itself is fully trustworthy, a bucket can still be adversarial — for example, a bucket you do not control, a shared
+bucket writable by others, or one whose objects, metadata, or checksums were crafted by an attacker. If you synchronize
+*from* such a bucket, the data and metadata it serves are already untrusted at the source, and s3sync's guarantees no
+longer apply. A trusted storage provider hosting an untrusted bucket is, for the purposes of this security model, an
+untrusted source.
+
+Synchronizing with an untrusted, compromised, or non-conformant endpoint or bucket is outside s3sync's security model.
+Selecting a trustworthy storage provider, and ensuring that every bucket you synchronize with is one you control or
+trust — including its credentials, encryption, and access policies — remains your responsibility.
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ S3-compatible storage is not part of that test matrix and is no longer tested at
 official certification for S3-compatible storage and behavior varies across providers, comprehensive testing is not
 possible. Bug reports, questions, and assistance requests regarding S3-compatible storage will not be addressed.
 
-## Security assumption (Trust model)
+## Security assumptions
 
 s3sync is built on a fundamental security assumption: **both the object storage system and the specific bucket you
 synchronize with must be trusted.**

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ correctly.
 
   </details>
 
-  You can check the synchronization status of the object's tagging, metadata, annnotation with
+  You can check the synchronization status of the object's tagging, metadata, annotation with
   `--report-metadata-sync-status`,
   `--report-tagging-sync-status` and `--report-annotations-sync-status` option.
 

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -345,7 +345,7 @@ It cannot work with between different object storages or regions."#)]
 
     #[arg(long, env, value_parser = storage_class::parse_storage_class, help_heading = "Target Options",
     long_help = r#"Type of storage to use for the target object.
-Valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONE-ZONE_IA | INTELLIGENT_TIERING | GLACIER |
+Valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER |
                DEEP_ARCHIVE | GLACIER_IR | EXPRESS_ONEZONE"#)]
     storage_class: Option<String>,
 

--- a/src/config/args/value_parser/metadata.rs
+++ b/src/config/args/value_parser/metadata.rs
@@ -13,10 +13,6 @@ pub fn check_metadata(metadata: &str) -> Result<String, String> {
         return Err(INVALID_METADATA.to_string());
     }
 
-    if mat.unwrap().as_str() != metadata {
-        return Err(INVALID_METADATA.to_string());
-    }
-
     Ok(metadata.to_string())
 }
 

--- a/src/config/args/value_parser/metadata.rs
+++ b/src/config/args/value_parser/metadata.rs
@@ -5,7 +5,8 @@ use regex::Regex;
 const INVALID_METADATA: &str = "invalid metadata.";
 
 pub fn check_metadata(metadata: &str) -> Result<String, String> {
-    let regex = Regex::new(r"(,?([a-zA-Z0-9_\-.]+)=([a-zA-Z0-9_\-.]*))+").unwrap();
+    let regex = Regex::new(r"^[a-zA-Z0-9_.-]+=[a-zA-Z0-9_.-]*(,[a-zA-Z0-9_.-]+=[a-zA-Z0-9_.-]*)*$")
+        .unwrap();
 
     let mat = regex.find(metadata);
     if mat.is_none() {
@@ -53,6 +54,7 @@ mod tests {
         assert!(check_metadata("key=value,key1=value=3,").is_err());
         assert!(check_metadata("key#1=value").is_err());
         assert!(check_metadata("key1=value^").is_err());
+        assert!(check_metadata(",key=value").is_err());
     }
 
     #[test]

--- a/src/config/args/value_parser/storage_class.rs
+++ b/src/config/args/value_parser/storage_class.rs
@@ -1,6 +1,6 @@
 use aws_sdk_s3::types::StorageClass;
 
-const INVALID_STORAGE_CLASS: &str = "invalid storage class. valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONE-ZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | GLACIER_IR | EXPRESS_ONEZONE.";
+const INVALID_STORAGE_CLASS: &str = "invalid storage class. valid choices: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | GLACIER_IR | EXPRESS_ONEZONE.";
 
 pub fn parse_storage_class(class: &str) -> Result<String, String> {
     #[allow(deprecated)]

--- a/src/config/args/value_parser/storage_path.rs
+++ b/src/config/args/value_parser/storage_path.rs
@@ -35,6 +35,9 @@ pub fn check_storage_path(path: &str) -> Result<String, String> {
             if parsed.host_str().is_none() {
                 return Err(NO_BUCKET_NAME_SPECIFIED.to_string());
             }
+            if !check_s3_prefix(path) {
+                return Err(INVALID_PATH.to_string());
+            }
         }
         _ => {
             if !is_windows_absolute_path(path) {
@@ -146,6 +149,11 @@ fn parse_s3_path(path: &str) -> StoragePath {
     StoragePath::S3 { bucket, prefix }
 }
 
+fn check_s3_prefix(path: &str) -> bool {
+    let prefix = Url::parse(path).unwrap().path().to_string();
+    percent_decode_str(&prefix).decode_utf8().is_ok()
+}
+
 fn is_windows_absolute_path(path: &str) -> bool {
     if !cfg!(windows) {
         return false;
@@ -197,6 +205,7 @@ mod tests {
         init_dummy_tracing_subscriber();
 
         assert!(check_storage_path("s3://arn:aws").is_err());
+        assert!(check_storage_path("s3://my-bucket/%FF").is_err());
     }
 
     #[test]

--- a/src/pipeline/diff_detector/etag_diff_detector.rs
+++ b/src/pipeline/diff_detector/etag_diff_detector.rs
@@ -653,9 +653,9 @@ impl ETagDiffDetector {
                     .get_object_parts(
                         key,
                         None,
-                        self.config.target_sse_c.clone(),
-                        self.config.target_sse_c_key.clone(),
-                        self.config.target_sse_c_key_md5.clone(),
+                        self.config.source_sse_c.clone(),
+                        self.config.source_sse_c_key.clone(),
+                        self.config.source_sse_c_key_md5.clone(),
                     )
                     .await
                 {

--- a/src/pipeline/diff_detector/etag_diff_detector.rs
+++ b/src/pipeline/diff_detector/etag_diff_detector.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use async_trait::async_trait;
 use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::types::ServerSideEncryption;
@@ -408,8 +407,8 @@ impl ETagDiffDetector {
                             .await?
                         }
                     }
-                    _ => {
-                        return Err(anyhow!("get_object_parts() failed. key={}.", key,));
+                    Err(error) => {
+                        return Err(error);
                     }
                 }
             } else {
@@ -681,8 +680,8 @@ impl ETagDiffDetector {
                             .await?
                         }
                     }
-                    _ => {
-                        return Err(anyhow!("get_object_parts() failed. key={}.", key,));
+                    Err(error) => {
+                        return Err(error);
                     }
                 }
             } else {
@@ -1530,12 +1529,7 @@ mod tests {
         let result = diff_detector
             .is_source_local_e_tag_different_from_target_s3("6byte.dat", &head_object_output)
             .await;
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("get_object_parts() failed.")
-        );
+        assert!(result.is_err())
     }
 
     #[tokio::test]
@@ -1632,12 +1626,7 @@ mod tests {
         let result = diff_detector
             .is_target_local_e_tag_different_from_source_s3("6byte.dat", &source_object)
             .await;
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("get_object_parts() failed.")
-        );
+        assert!(result.is_err())
     }
 
     #[tokio::test]

--- a/src/pipeline/head_object_checker.rs
+++ b/src/pipeline/head_object_checker.rs
@@ -5,7 +5,7 @@ use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_runtime_api::http::Response;
 use aws_smithy_types::body::SdkBody;
 use std::sync::{Arc, Mutex};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::pipeline::diff_detector::always_different_diff_detector::AlwaysDifferentDiffDetector;
 use crate::pipeline::diff_detector::checksum_diff_detector::ChecksumDiffDetector;
@@ -16,7 +16,7 @@ use crate::pipeline::diff_detector::standard_diff_detector::StandardDiffDetector
 use crate::Config;
 use crate::storage::Storage;
 use crate::storage::local::fs_util::check_directory_traversal;
-use crate::types::SyncStatistics::{SyncError, SyncWarning};
+use crate::types::SyncStatistics::SyncWarning;
 use crate::types::error::S3syncError;
 use crate::types::event_callback::{EventData, EventType};
 use crate::types::token::PipelineCancellationToken;
@@ -225,26 +225,7 @@ impl HeadObjectChecker {
             return (Ok(true), None);
         }
 
-        self.target
-            .send_stats(SyncError {
-                key: key.to_string(),
-            })
-            .await;
-
-        let error = head_target_object_output
-            .as_ref()
-            .err()
-            .unwrap()
-            .to_string();
-        let source = head_target_object_output.as_ref().err().unwrap().source();
-        error!(
-            worker_index = self.worker_index,
-            error = error,
-            source = source,
-            "head_object() failed."
-        );
-
-        (Err(anyhow!("head_object() failed. key={}.", key,)), None)
+        (Err(head_target_object_output.err().unwrap()), None)
     }
 
     fn is_head_object_check_required(&self) -> bool {

--- a/src/pipeline/syncer.rs
+++ b/src/pipeline/syncer.rs
@@ -27,14 +27,17 @@ use anyhow::{Context, Error, Result, anyhow};
 use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError;
 use aws_sdk_s3::operation::copy_object::CopyObjectError;
 use aws_sdk_s3::operation::delete_object::{DeleteObjectError, DeleteObjectOutput};
+use aws_sdk_s3::operation::delete_object_annotation::DeleteObjectAnnotationError;
 use aws_sdk_s3::operation::delete_object_tagging::DeleteObjectTaggingError;
 use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
+use aws_sdk_s3::operation::get_object_annotation::GetObjectAnnotationError;
 use aws_sdk_s3::operation::get_object_attributes::GetObjectAttributesError;
 use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::list_object_annotations::ListObjectAnnotationsError;
 use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsError;
 use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
+use aws_sdk_s3::operation::put_object_annotation::PutObjectAnnotationError;
 use aws_sdk_s3::operation::put_object_tagging::PutObjectTaggingError;
 use aws_sdk_s3::operation::upload_part_copy::UploadPartCopyError;
 use aws_sdk_s3::types::builders::ObjectPartBuilder;
@@ -2680,6 +2683,25 @@ fn is_force_retryable_error(e: &Error) -> bool {
         return is_force_sdk_retryable_error(error);
     }
 
+    if let Some(error) = e.downcast_ref::<SdkError<ListObjectAnnotationsError, Response<SdkBody>>>()
+    {
+        return is_force_sdk_retryable_error(error);
+    }
+
+    if let Some(error) = e.downcast_ref::<SdkError<GetObjectAnnotationError, Response<SdkBody>>>() {
+        return is_force_sdk_retryable_error(error);
+    }
+
+    if let Some(error) = e.downcast_ref::<SdkError<PutObjectAnnotationError, Response<SdkBody>>>() {
+        return is_force_sdk_retryable_error(error);
+    }
+
+    if let Some(error) =
+        e.downcast_ref::<SdkError<DeleteObjectAnnotationError, Response<SdkBody>>>()
+    {
+        return is_force_sdk_retryable_error(error);
+    }
+
     let s3sync_error = e.downcast_ref::<S3syncError>();
     if s3sync_error.is_some() {
         return matches!(
@@ -2979,6 +3001,18 @@ mod tests {
         )));
         assert!(is_force_retryable_error(&anyhow!(
             build_list_object_versions_timeout_error()
+        )));
+        assert!(is_force_retryable_error(&anyhow!(
+            build_list_object_annotations_timeout_error()
+        )));
+        assert!(is_force_retryable_error(&anyhow!(
+            build_get_object_annotation_timeout_error()
+        )));
+        assert!(is_force_retryable_error(&anyhow!(
+            build_put_object_annotation_timeout_error()
+        )));
+        assert!(is_force_retryable_error(&anyhow!(
+            build_delete_object_annotation_timeout_error()
         )));
 
         assert!(!is_force_retryable_error(&anyhow!("error")));
@@ -3893,6 +3927,26 @@ mod tests {
 
     fn build_list_object_versions_timeout_error()
     -> SdkError<ListObjectVersionsError, Response<SdkBody>> {
+        SdkError::timeout_error("timeout_error")
+    }
+
+    fn build_list_object_annotations_timeout_error()
+    -> SdkError<ListObjectAnnotationsError, Response<SdkBody>> {
+        SdkError::timeout_error("timeout_error")
+    }
+
+    fn build_get_object_annotation_timeout_error()
+    -> SdkError<GetObjectAnnotationError, Response<SdkBody>> {
+        SdkError::timeout_error("timeout_error")
+    }
+
+    fn build_put_object_annotation_timeout_error()
+    -> SdkError<PutObjectAnnotationError, Response<SdkBody>> {
+        SdkError::timeout_error("timeout_error")
+    }
+
+    fn build_delete_object_annotation_timeout_error()
+    -> SdkError<DeleteObjectAnnotationError, Response<SdkBody>> {
         SdkError::timeout_error("timeout_error")
     }
 

--- a/src/pipeline/syncer.rs
+++ b/src/pipeline/syncer.rs
@@ -1643,19 +1643,14 @@ impl ObjectSyncer {
                 .context("pipeline::syncer::get_first_chunk_range() failed.");
 
             if head_object_result.is_err() {
-                error!(
-                    worker_index = self.worker_index,
-                    key = object.key(),
-                    "pipeline::syncer::get_first_chunk_range() failed."
-                );
+                let error = match head_object_result {
+                    Ok(_) => {
+                        unreachable!("successful head_object() result should have returned earlier")
+                    }
+                    Err(error) => error,
+                };
 
-                self.base
-                    .send_stats(SyncError {
-                        key: object.key().to_string(),
-                    })
-                    .await;
-
-                return Err(anyhow!("pipeline::syncer::get_first_chunk_range() failed."));
+                return Err(error);
             }
 
             return Ok(Some(format!(

--- a/src/pipeline/syncer.rs
+++ b/src/pipeline/syncer.rs
@@ -1640,22 +1640,11 @@ impl ObjectSyncer {
                     self.base.config.source_sse_c_key_md5.clone(),
                 )
                 .await
-                .context("pipeline::syncer::get_first_chunk_range() failed.");
-
-            if head_object_result.is_err() {
-                let error = match head_object_result {
-                    Ok(_) => {
-                        unreachable!("successful head_object() result should have returned earlier")
-                    }
-                    Err(error) => error,
-                };
-
-                return Err(error);
-            }
+                .context("pipeline::syncer::get_first_chunk_range() failed.")?;
 
             return Ok(Some(format!(
                 "bytes=0-{}",
-                head_object_result?.content_length.unwrap() - 1
+                head_object_result.content_length.unwrap() - 1
             )));
         }
 

--- a/src/storage/local/mod.rs
+++ b/src/storage/local/mod.rs
@@ -590,18 +590,34 @@ impl LocalStorage {
         file.flush().await?;
         drop(file);
 
-        let real_path = fs_util::key_to_file_path(self.path.to_path_buf(), key);
-        temp_file.persist(&real_path)?;
-
-        fs_util::set_last_modified(self.path.to_path_buf(), key, seconds, nanos)?;
-
         let target_object_parts = if let Some(object_checksum) = &object_checksum {
             object_checksum.object_parts.clone()
         } else {
             None
         };
 
-        let target_content_length = fs_util::get_file_size(&real_path).await?;
+        let target_content_length = fs_util::get_file_size(&temp_file.path().to_path_buf()).await?;
+        self.verify_local_file(
+            key,
+            object_checksum,
+            &source_sse,
+            &source_e_tag,
+            source_content_length,
+            source_final_checksum,
+            source_checksum_algorithm,
+            &temp_file.path().to_path_buf(),
+            target_object_parts,
+            target_content_length,
+            source_storage_class == Some(StorageClass::ExpressOnezone),
+            source_version_id.clone(),
+            source_last_modified_raw,
+        )
+        .await?;
+
+        let real_path = fs_util::key_to_file_path(self.path.to_path_buf(), key);
+        temp_file.persist(&real_path)?;
+
+        fs_util::set_last_modified(self.path.to_path_buf(), key, seconds, nanos)?;
 
         let mut event_data = EventData::new(EventType::SYNC_WRITE);
         event_data.key = Some(key.to_string());
@@ -621,23 +637,6 @@ impl LocalStorage {
         event_data.source_size = Some(source_content_length);
         event_data.target_size = Some(target_content_length);
         self.config.event_manager.trigger_event(event_data).await;
-
-        self.verify_local_file(
-            key,
-            object_checksum,
-            &source_sse,
-            &source_e_tag,
-            source_content_length,
-            source_final_checksum,
-            source_checksum_algorithm,
-            &real_path,
-            target_object_parts,
-            target_content_length,
-            source_storage_class == Some(StorageClass::ExpressOnezone),
-            source_version_id,
-            source_last_modified_raw,
-        )
-        .await?;
 
         let lossy_path = real_path.to_string_lossy().to_string();
         info!(

--- a/src/storage/local/mod.rs
+++ b/src/storage/local/mod.rs
@@ -949,6 +949,30 @@ impl LocalStorage {
         file.flush().await?;
         drop(file);
 
+        let target_object_parts = if let Some(object_checksum) = &object_checksum {
+            object_checksum.object_parts.clone()
+        } else {
+            None
+        };
+
+        let target_content_length = fs_util::get_file_size(&temp_file.path().to_path_buf()).await?;
+        self.verify_local_file(
+            key,
+            object_checksum,
+            &source_sse,
+            &source_e_tag,
+            source_size,
+            source_additional_checksum,
+            source_checksum_algorithm,
+            &temp_file.path().to_path_buf(),
+            target_object_parts,
+            target_content_length,
+            source_storage_class == Some(StorageClass::ExpressOnezone),
+            source_version_id.clone(),
+            source_last_modified_raw,
+        )
+        .await?;
+
         let real_path = fs_util::key_to_file_path(self.path.to_path_buf(), key);
         temp_file.persist(&real_path)?;
 
@@ -958,12 +982,6 @@ impl LocalStorage {
             source_last_modified_seconds,
             source_last_modified_nanos,
         )?;
-
-        let target_object_parts = if let Some(object_checksum) = &object_checksum {
-            object_checksum.object_parts.clone()
-        } else {
-            None
-        };
 
         let total_upload_size: u64 = shared_total_upload_size.lock().unwrap().iter().sum();
         if total_upload_size == source_size {
@@ -978,8 +996,6 @@ impl LocalStorage {
             )));
         }
 
-        let target_content_length = fs_util::get_file_size(&real_path).await?;
-
         let mut event_data = EventData::new(EventType::SYNC_COMPLETE);
         event_data.key = Some(key.to_string());
         // skipcq: RS-W1070
@@ -990,23 +1006,6 @@ impl LocalStorage {
         event_data.source_size = Some(source_size);
         event_data.target_size = Some(target_content_length);
         self.config.event_manager.trigger_event(event_data).await;
-
-        self.verify_local_file(
-            key,
-            object_checksum,
-            &source_sse,
-            &source_e_tag,
-            source_size,
-            source_additional_checksum,
-            source_checksum_algorithm,
-            &real_path,
-            target_object_parts,
-            target_content_length,
-            source_storage_class == Some(StorageClass::ExpressOnezone),
-            source_version_id,
-            source_last_modified_raw,
-        )
-        .await?;
 
         let lossy_path = real_path.to_string_lossy().to_string();
         info!(

--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -1597,12 +1597,12 @@ impl StorageTrait for S3Storage {
         if version_id.is_some() {
             return format!(
                 "{}/{}?versionId={}",
-                &self.bucket,
+                self.bucket,
                 full_key,
                 version_id.unwrap()
             );
         }
-        format!("{}/{}", &self.bucket, full_key)
+        format!("{}/{}", self.bucket, full_key)
     }
 
     fn set_warning(&self) {

--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -2066,8 +2066,6 @@ mod tests {
         );
     }
 
-    // ... existing code ...
-
     #[tokio::test]
     async fn send_object_versions_with_sort_test_same_time() {
         init_dummy_tracing_subscriber();

--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -243,7 +243,12 @@ impl S3Storage {
         sender: &Sender<S3syncObject>,
         object_versions: &mut ObjectVersions,
     ) -> Result<()> {
-        object_versions.sort_by(|a, b| {
+        let mut indexed_object_versions = object_versions
+            .drain(..)
+            .enumerate()
+            .collect::<Vec<(usize, S3syncObject)>>();
+
+        indexed_object_versions.sort_by(|(a_index, a), (b_index, b)| {
             if a.is_latest() {
                 return Ordering::Greater;
             }
@@ -254,7 +259,17 @@ impl S3Storage {
             a.last_modified()
                 .as_nanos()
                 .cmp(&b.last_modified().as_nanos())
+                // ListObjectVersions returns versions for the same key in newest-first order.
+                // LastModified may only have second-level precision, so equal timestamps must
+                // be replayed by reversing the original listing order.
+                .then_with(|| b_index.cmp(a_index))
         });
+
+        object_versions.extend(
+            indexed_object_versions
+                .into_iter()
+                .map(|(_, object)| object),
+        );
 
         for object in object_versions {
             debug!(
@@ -2048,6 +2063,78 @@ mod tests {
         assert_eq!(
             receive_version_ids(&receiver, 3).await,
             vec!["v-old", "v-mid", "v-latest"]
+        );
+    }
+
+    // ... existing code ...
+
+    #[tokio::test]
+    async fn send_object_versions_with_sort_test_same_time() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::unbounded::<S3syncObject>();
+
+        // The latest version is placed at the end of the input so that the
+        // comparator evaluates it as `a`(a.is_latest() => Ordering::Greater).
+        let mut object_versions = vec![
+            build_versioning_object("v-mid", false, 200),
+            build_versioning_object("v-old", false, 100),
+            build_versioning_object("v-latest", true, 300),
+        ];
+        S3Storage::send_object_versions_with_sort(&sender, &mut object_versions)
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_version_ids(&receiver, 3).await,
+            vec!["v-old", "v-mid", "v-latest"]
+        );
+
+        // The latest version is placed at the beginning of the input so that the
+        // comparator evaluates it as `b`(b.is_latest() => Ordering::Less).
+        let mut object_versions = vec![
+            build_versioning_object("v-latest", true, 300),
+            build_versioning_object("v-mid", false, 200),
+            build_versioning_object("v-old", false, 100),
+        ];
+        S3Storage::send_object_versions_with_sort(&sender, &mut object_versions)
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_version_ids(&receiver, 3).await,
+            vec!["v-old", "v-mid", "v-latest"]
+        );
+
+        // ListObjectVersions returns same-key versions in newest-first order.
+        // If LastModified timestamps are equal, replay order must reverse the
+        // original listing order so that older versions are sent first.
+        let mut object_versions = vec![
+            build_versioning_object("v-newer-same-second", false, 400),
+            build_versioning_object("v-older-same-second", false, 400),
+        ];
+        S3Storage::send_object_versions_with_sort(&sender, &mut object_versions)
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_version_ids(&receiver, 2).await,
+            vec!["v-older-same-second", "v-newer-same-second"]
+        );
+
+        // Even when timestamps are equal, the latest version must still be sent last.
+        let mut object_versions = vec![
+            build_versioning_object("v-latest-same-second", true, 500),
+            build_versioning_object("v-newer-same-second", false, 500),
+            build_versioning_object("v-older-same-second", false, 500),
+        ];
+        S3Storage::send_object_versions_with_sort(&sender, &mut object_versions)
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_version_ids(&receiver, 3).await,
+            vec![
+                "v-older-same-second",
+                "v-newer-same-second",
+                "v-latest-same-second"
+            ]
         );
     }
 

--- a/src/storage/s3/upload_manager.rs
+++ b/src/storage/s3/upload_manager.rs
@@ -336,11 +336,34 @@ impl UploadManager {
                 self.config.content_type.clone()
             },
             expires: if self.config.expires.is_none() {
-                get_object_output_first_chunk
-                    .expires_string()
-                    .and_then(|expires_string| {
-                        DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
+                let expires_string =
+                    get_object_output_first_chunk
+                        .expires_string()
+                        .and_then(|expires_string| {
+                            DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
+                        });
+
+                if expires_string.is_none() {
+                    self.send_stats(SyncWarning {
+                        key: key.to_string(),
                     })
+                    .await;
+                    self.has_warning.store(true, Ordering::SeqCst);
+
+                    let message = format!(
+                        "Invalid expires value {}, falling back to None",
+                        get_object_output_first_chunk
+                            .expires_string()
+                            .unwrap_or_default()
+                    );
+                    warn!(key = &key, message);
+
+                    let mut event_data = EventData::new(EventType::SYNC_WARNING);
+                    event_data.key = Some(key.to_string());
+                    event_data.message = Some(message.to_string());
+                    self.config.event_manager.trigger_event(event_data).await;
+                }
+                expires_string
             } else {
                 Some(DateTime::from_str(
                     &self.config.expires.unwrap().to_rfc3339(),
@@ -1522,11 +1545,32 @@ impl UploadManager {
                 self.config.content_type.clone()
             },
             expires: if self.config.expires.is_none() {
-                get_object_output
-                    .expires_string()
-                    .and_then(|expires_string| {
-                        DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
+                let expires_string =
+                    get_object_output
+                        .expires_string()
+                        .and_then(|expires_string| {
+                            DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
+                        });
+
+                if expires_string.is_none() {
+                    self.send_stats(SyncWarning {
+                        key: key.to_string(),
                     })
+                    .await;
+                    self.has_warning.store(true, Ordering::SeqCst);
+
+                    let message = format!(
+                        "Invalid expires value {}, falling back to None",
+                        get_object_output.expires_string().unwrap_or_default()
+                    );
+                    warn!(key = &key, message);
+
+                    let mut event_data = EventData::new(EventType::SYNC_WARNING);
+                    event_data.key = Some(key.to_string());
+                    event_data.message = Some(message.to_string());
+                    self.config.event_manager.trigger_event(event_data).await;
+                }
+                expires_string
             } else {
                 Some(DateTime::from_str(
                     &self.config.expires.unwrap().to_rfc3339(),

--- a/src/storage/s3/upload_manager.rs
+++ b/src/storage/s3/upload_manager.rs
@@ -823,7 +823,7 @@ impl UploadManager {
                             error!("get_object() returned no content range. This is unexpected.");
                             return Err(anyhow!(
                                 "get_object() returned no content range. This is unexpected. key={}.",
-                                &target_key
+                                target_key
                             ));
                         }
                         let (request_start, request_end) = parse_range_header_string(&range)
@@ -1195,7 +1195,7 @@ impl UploadManager {
                             );
                             return Err(anyhow!(
                                 "get_object() returned no content range. This is unexpected. key={}.",
-                                &target_key
+                                target_key
                             ));
                         }
                         let (request_start, request_end) = parse_range_header_string(&range)

--- a/src/storage/s3/upload_manager.rs
+++ b/src/storage/s3/upload_manager.rs
@@ -336,6 +336,7 @@ impl UploadManager {
                 self.config.content_type.clone()
             },
             expires: if self.config.expires.is_none() {
+                let raw_expires_string = get_object_output_first_chunk.expires_string();
                 let expires_string =
                     get_object_output_first_chunk
                         .expires_string()
@@ -343,7 +344,7 @@ impl UploadManager {
                             DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
                         });
 
-                if expires_string.is_none() {
+                if raw_expires_string.is_some() && expires_string.is_none() {
                     self.send_stats(SyncWarning {
                         key: key.to_string(),
                     })
@@ -1545,6 +1546,7 @@ impl UploadManager {
                 self.config.content_type.clone()
             },
             expires: if self.config.expires.is_none() {
+                let raw_expires_string = get_object_output.expires_string();
                 let expires_string =
                     get_object_output
                         .expires_string()
@@ -1552,7 +1554,7 @@ impl UploadManager {
                             DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
                         });
 
-                if expires_string.is_none() {
+                if raw_expires_string.is_some() && expires_string.is_none() {
                     self.send_stats(SyncWarning {
                         key: key.to_string(),
                     })

--- a/src/storage/s3/upload_manager.rs
+++ b/src/storage/s3/upload_manager.rs
@@ -338,8 +338,8 @@ impl UploadManager {
             expires: if self.config.expires.is_none() {
                 get_object_output_first_chunk
                     .expires_string()
-                    .map(|expires_string| {
-                        DateTime::from_str(expires_string, DateTimeFormat::HttpDate).unwrap()
+                    .and_then(|expires_string| {
+                        DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
                     })
             } else {
                 Some(DateTime::from_str(
@@ -1522,9 +1522,11 @@ impl UploadManager {
                 self.config.content_type.clone()
             },
             expires: if self.config.expires.is_none() {
-                get_object_output.expires_string().map(|expires_string| {
-                    DateTime::from_str(expires_string, DateTimeFormat::HttpDate).unwrap()
-                })
+                get_object_output
+                    .expires_string()
+                    .and_then(|expires_string| {
+                        DateTime::from_str(expires_string, DateTimeFormat::HttpDate).ok()
+                    })
             } else {
                 Some(DateTime::from_str(
                     &self.config.expires.unwrap().to_rfc3339(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -322,6 +322,7 @@ impl S3syncObject {
         match &self {
             Self::Versioning(object) => object.size().unwrap(),
             Self::NotVersioning(object) => object.size().unwrap(),
+            Self::DeleteMarker(maker) => 0,
             _ => panic!("doesn't have size."),
         }
     }
@@ -339,7 +340,8 @@ impl S3syncObject {
         match &self {
             Self::Versioning(object) => object.e_tag(),
             Self::NotVersioning(object) => object.e_tag(),
-            _ => panic!("doesn't have ETag."),
+            Self::DeleteMarker(object) => None,
+            _ => panic!("unsupported."),
         }
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -322,7 +322,7 @@ impl S3syncObject {
         match &self {
             Self::Versioning(object) => object.size().unwrap(),
             Self::NotVersioning(object) => object.size().unwrap(),
-            Self::DeleteMarker(maker) => 0,
+            Self::DeleteMarker(_object) => 0,
             _ => panic!("doesn't have size."),
         }
     }
@@ -340,7 +340,7 @@ impl S3syncObject {
         match &self {
             Self::Versioning(object) => object.e_tag(),
             Self::NotVersioning(object) => object.e_tag(),
-            Self::DeleteMarker(object) => None,
+            Self::DeleteMarker(_object) => None,
             _ => panic!("unsupported."),
         }
     }


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `ONEZONE_IA` naming across CLI help, validation, and messaging.
  - Improved deterministic ordering for S3 version replay when timestamps match.
  - Corrected SSE-C ETag and made related checks less sensitive to exact error text.
  - Prevented panics and improved handling for delete markers, invalid expirations, and malformed HTTP-date values (with warnings).
  - Hardened S3 path validation and stricter `key=value` metadata parsing.
  - Expanded retry behavior for object annotation-related AWS errors.
- **Documentation**
  - Updated `--storage-class` valid choices and added “Security assumptions”.
- **Tests**
  - Added/extended coverage for same-timestamp ordering and invalid S3 path/metadata cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->