### PR TITLE
Fix/fable 20260719

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Credential-related command line options (`--source-access-key`, `--source-secret-access-key`,
+  `--source-session-token`, `--target-access-key`, `--target-secret-access-key`, `--target-session-token`,
+  `--source-sse-c-key`, `--source-sse-c-key-md5`, `--target-sse-c-key`, `--target-sse-c-key-md5`) no longer
+  display their values in `--help` output when set via environment variables.
+
 ### Fixed
 
 - Corrected `ONE-ZONE_IA` to `ONEZONE_IA` in `--storage-class`/`--annotation-storage-class` options and documentation.

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -655,7 +655,13 @@ Example: 2025-07-16T12:00:00Z"#
     source_sse_c_key: Option<String>,
 
     /// Source base64 encoded MD5 digest of source_sse_c_key
-    #[arg(long, env, hide_env_values = true, requires = "source_sse_c", help_heading = "Encryption")]
+    #[arg(
+        long,
+        env,
+        hide_env_values = true,
+        requires = "source_sse_c",
+        help_heading = "Encryption"
+    )]
     source_sse_c_key_md5: Option<String>,
 
     /// Target SSE-C algorithm. Valid choices: AES256
@@ -673,7 +679,13 @@ Example: 2025-07-16T12:00:00Z"#
     target_sse_c_key: Option<String>,
 
     /// Target base64 encoded MD5 digest of target-sse-c-key
-    #[arg(long, env, hide_env_values = true, requires = "target_sse_c", help_heading = "Encryption")]
+    #[arg(
+        long,
+        env,
+        hide_env_values = true,
+        requires = "target_sse_c",
+        help_heading = "Encryption"
+    )]
     target_sse_c_key_md5: Option<String>,
 
     /// Trace verbosity(-v: show info, -vv: show debug, -vvv show trace)

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -262,15 +262,15 @@ It cannot work with between different object storages or regions."#)]
     source_profile: Option<String>,
 
     /// Source access key
-    #[arg(long, env, conflicts_with_all = ["source_profile"], requires = "source_secret_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["source_profile"], requires = "source_secret_access_key", help_heading = "AWS Configuration")]
     source_access_key: Option<String>,
 
     /// Source secret access key
-    #[arg(long, env, conflicts_with_all = ["source_profile"], requires = "source_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["source_profile"], requires = "source_access_key", help_heading = "AWS Configuration")]
     source_secret_access_key: Option<String>,
 
     /// Source session token
-    #[arg(long, env, conflicts_with_all = ["source_profile"], requires = "source_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["source_profile"], requires = "source_access_key", help_heading = "AWS Configuration")]
     source_session_token: Option<String>,
 
     /// Source region
@@ -312,15 +312,15 @@ It cannot work with between different object storages or regions."#)]
     target_profile: Option<String>,
 
     /// Target access key
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_secret_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_secret_access_key", help_heading = "AWS Configuration")]
     target_access_key: Option<String>,
 
     /// Target secret access key
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_access_key", help_heading = "AWS Configuration")]
     target_secret_access_key: Option<String>,
 
     /// Target session token
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_access_key", help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_access_key", help_heading = "AWS Configuration")]
     target_session_token: Option<String>,
 
     /// Target region
@@ -648,13 +648,14 @@ Example: 2025-07-16T12:00:00Z"#
     #[arg(
         long,
         env,
+        hide_env_values = true,
         requires = "source_sse_c_key_md5",
         help_heading = "Encryption"
     )]
     source_sse_c_key: Option<String>,
 
     /// Source base64 encoded MD5 digest of source_sse_c_key
-    #[arg(long, env, requires = "source_sse_c", help_heading = "Encryption")]
+    #[arg(long, env, hide_env_values = true, requires = "source_sse_c", help_heading = "Encryption")]
     source_sse_c_key_md5: Option<String>,
 
     /// Target SSE-C algorithm. Valid choices: AES256
@@ -665,13 +666,14 @@ Example: 2025-07-16T12:00:00Z"#
     #[arg(
         long,
         env,
+        hide_env_values = true,
         requires = "target_sse_c_key_md5",
         help_heading = "Encryption"
     )]
     target_sse_c_key: Option<String>,
 
     /// Target base64 encoded MD5 digest of target-sse-c-key
-    #[arg(long, env, requires = "target_sse_c", help_heading = "Encryption")]
+    #[arg(long, env, hide_env_values = true, requires = "target_sse_c", help_heading = "Encryption")]
     target_sse_c_key_md5: Option<String>,
 
     /// Trace verbosity(-v: show info, -vv: show debug, -vvv show trace)


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive credential values provided through environment variables are no longer displayed in command-line `--help` output.
  * Applies to AWS credentials and customer-provided encryption keys and digests for source and target configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->