### PR TITLE
Fix/positional envvar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET` environment
+- [Breaking change] The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET` environment
   variables. These generic variable names could unintentionally override the command line arguments.
 
 ## [1.60.0] - 2026-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.60.1] - 2026-07-24
+## [1.61.0] - 2026-07-24
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.60.1] - 2026-07-24
+
+### Changed
+
+- The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET` environment
+  variables. These generic variable names could unintentionally override the command line arguments.
+
 ## [1.60.0] - 2026-07-20
 
 Monthly update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,7 +2708,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.60.0"
+version = "1.60.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,7 +2708,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.60.1"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.60.1"
+version = "1.61.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.60.0"
+version = "1.60.1"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -1280,8 +1280,8 @@ $ s3sync -h
 Usage: s3sync [OPTIONS] [SOURCE] [TARGET]
 
 Arguments:
-  [SOURCE]  s3://<BUCKET_NAME>[/prefix] or local path [env: SOURCE=]
-  [TARGET]  s3://<BUCKET_NAME>[/prefix] or local path [env: TARGET=]
+  [SOURCE]  s3://<BUCKET_NAME>[/prefix] or local path
+  [TARGET]  s3://<BUCKET_NAME>[/prefix] or local path
 
 Options:
   -v, --verbose...  Increase logging verbosity

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -230,10 +230,10 @@ shadow!(build);
 #[derive(Parser, Clone, Debug)]
 #[cfg_attr(feature = "version", command(version=format!("{} ({} {}), {}", build::PKG_VERSION, build::SHORT_COMMIT, build::BUILD_TARGET, build::RUST_VERSION)))]
 pub struct CLIArgs {
-    #[arg(env, help = "s3://<BUCKET_NAME>[/prefix] or local path", value_parser = storage_path::check_storage_path, default_value_if("auto_complete_shell", ArgPredicate::IsPresent, "s3://ignored"), required = false)]
+    #[arg(help = "s3://<BUCKET_NAME>[/prefix] or local path", value_parser = storage_path::check_storage_path, default_value_if("auto_complete_shell", ArgPredicate::IsPresent, "s3://ignored"), required = false)]
     source: String,
 
-    #[arg(env, help = "s3://<BUCKET_NAME>[/prefix] or local path", value_parser = storage_path::check_storage_path, default_value_if("auto_complete_shell", ArgPredicate::IsPresent, "s3://ignored"), required = false)]
+    #[arg(help = "s3://<BUCKET_NAME>[/prefix] or local path", value_parser = storage_path::check_storage_path, default_value_if("auto_complete_shell", ArgPredicate::IsPresent, "s3://ignored"), required = false)]
     target: String,
 
     /// A simulation mode. No actions will be performed.


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Positional `SOURCE` and `TARGET` arguments now consistently take precedence over generic `SOURCE`/`TARGET` environment variables, restoring expected command-line behavior.
* **Documentation**
  * Updated the `s3sync -h` help text to remove inline references to `SOURCE` and `TARGET` being set via environment variables.
* **Release**
  * Version **1.61.0** has been released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->