### PR TITLE
Add pipe-safe stdout handling to prevent panics on closed pipes, upda…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.61.2] - 2026-08-03
+
+### Fixed
+
+- Generating a shell completion script into a closed pipe (e.g. `s3sync --auto-complete-shell bash | head 1` when the reader exits without consuming the script) no longer panics with `failed to write completion file: Broken pipe`.
+
+
 ## [1.61.1] - 2026-07-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,7 +2717,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.61.1"
+version = "1.61.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.61.1"
+version = "1.61.2"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/src/bin/s3sync/main.rs
+++ b/src/bin/s3sync/main.rs
@@ -1,5 +1,5 @@
 use ::tracing::trace;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use rusty_fork::rusty_fork_test;
@@ -8,6 +8,7 @@ use s3sync::CLIArgs;
 use s3sync::Config;
 
 mod cli;
+mod pipe_safe;
 mod tracing;
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -16,14 +17,7 @@ async fn main() -> Result<()> {
     let config = load_config_exit_if_err();
 
     if let Some(shell) = config.auto_complete_shell {
-        generate(
-            shell,
-            &mut CLIArgs::command(),
-            "s3sync",
-            &mut std::io::stdout(),
-        );
-
-        return Ok(());
+        return print_completion_script(shell);
     }
 
     start_tracing_if_necessary(&config);
@@ -48,6 +42,20 @@ fn load_config_exit_if_err() -> Config {
     config
 }
 
+/// Render the shell-completion script for `shell` and print it pipe-safely.
+///
+/// clap_complete's generators panic on writer errors ("failed to write
+/// completion file"), so they never touch stdout directly: the script is
+/// rendered into an infallible in-memory buffer and written in one
+/// pipe-safe pass. A reader that exits early
+/// (`s3sync --auto-complete-shell bash | head 1`) yields exit 0; any other
+/// stdout write error fails the command.
+fn print_completion_script(shell: clap_complete::shells::Shell) -> Result<()> {
+    let mut script = Vec::new();
+    generate(shell, &mut CLIArgs::command(), "s3sync", &mut script);
+    pipe_safe::write_all_pipe_safe(&script).context("failed to write completion script")
+}
+
 fn start_tracing_if_necessary(config: &Config) -> bool {
     if config.tracing_config.is_none() {
         return false;
@@ -58,6 +66,14 @@ fn start_tracing_if_necessary(config: &Config) -> bool {
 }
 
 rusty_fork_test! {
+    // Runs in a forked child so the completion script written to the real
+    // stdout does not pollute the test harness output. The closed-pipe
+    // behavior itself is pinned process-level in tests/cli_broken_pipe.rs.
+    #[test]
+    fn print_completion_script_succeeds() {
+        print_completion_script(clap_complete::shells::Shell::Bash).unwrap();
+    }
+
     #[test]
     fn with_tracing() {
         let args = vec![

--- a/src/bin/s3sync/pipe_safe.rs
+++ b/src/bin/s3sync/pipe_safe.rs
@@ -1,0 +1,102 @@
+//! Pipe-safe stdout printing.
+//!
+//! Writing to stdout panics when it is a pipe whose reader has already gone
+//! away — piping to a `head`/`grep -q`/pager that exited before the output
+//! ended, or `s3sync --auto-complete-shell bash | head 1`, where `head`
+//! fails to open the file `1` and never reads. Pre-rendered stdout output
+//! goes through this helper instead: `BrokenPipe` is swallowed — a reader
+//! that stops early is a normal way for a pipeline to end — so the command
+//! still exits 0. Any other write error (full disk or I/O error on a
+//! redirect) is propagated so the command fails loudly instead of silently
+//! dropping output.
+//!
+//! The tracing counterpart is `tracing::PipeSafeWriter`, and the progress
+//! indicator writes its trailing newline best-effort; both already ignore
+//! closed pipes.
+
+use std::io::{ErrorKind, Write};
+
+/// Write `bytes` to stdout as-is (no trailing newline), swallowing
+/// BrokenPipe. Used for pre-rendered output such as shell-completion
+/// scripts.
+pub fn write_all_pipe_safe(bytes: &[u8]) -> std::io::Result<()> {
+    write_all_ignoring_broken_pipe(&mut std::io::stdout().lock(), bytes)
+}
+
+fn write_all_ignoring_broken_pipe(writer: &mut impl Write, bytes: &[u8]) -> std::io::Result<()> {
+    ignore_broken_pipe(writer.write_all(bytes).and_then(|()| writer.flush()))
+}
+
+fn ignore_broken_pipe(result: std::io::Result<()>) -> std::io::Result<()> {
+    match result {
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fails writes (or, with `fail_flush`, only the flush) with `kind`.
+    /// The real closed-pipe scenario is exercised process-level by
+    /// `tests/cli_broken_pipe.rs`.
+    struct FailWriter {
+        kind: ErrorKind,
+        fail_flush: bool,
+    }
+
+    impl Write for FailWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.fail_flush {
+                Ok(buf.len())
+            } else {
+                Err(std::io::Error::new(self.kind, "simulated write failure"))
+            }
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            if self.fail_flush {
+                Err(std::io::Error::new(self.kind, "simulated flush failure"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn write_all_passes_bytes_through_verbatim() {
+        let mut buf = Vec::new();
+        write_all_ignoring_broken_pipe(&mut buf, b"complete -c s3sync\n").unwrap();
+        assert_eq!(buf, b"complete -c s3sync\n");
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_write() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: false,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: true,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_propagates_other_errors() {
+        // A failed redirect (disk full, I/O error) must still fail the
+        // command — only a vanished reader is benign.
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: false,
+        };
+        let err = write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+}

--- a/tests/cli_broken_pipe.rs
+++ b/tests/cli_broken_pipe.rs
@@ -1,0 +1,80 @@
+//! Process-level broken-pipe regression tests. No AWS access is needed:
+//! completions, help, and version output never leave the process.
+//!
+//! Each test hands the child a stdout whose read end is already closed, so
+//! every stdout write in the child fails with `BrokenPipe` from the first
+//! byte — exactly the `s3sync --auto-complete-shell bash | head 1` case,
+//! where `head` fails to open the file `1` and exits without reading its
+//! input (and the worst case of any consumer that stops reading early).
+//! The binary must exit through its normal success path: never panic
+//! ("failed to write completion file: ... Broken pipe") and never die of
+//! SIGPIPE (which would surface here as `status.code() == None`).
+
+use std::process::{Command, Stdio};
+
+fn s3sync_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_s3sync"));
+    // None of these paths need AWS configuration; clear it for isolation.
+    command.env_remove("AWS_PROFILE");
+    command.env_remove("AWS_ACCESS_KEY_ID");
+    command.env_remove("AWS_SECRET_ACCESS_KEY");
+    command.env_remove("AWS_SESSION_TOKEN");
+    command.env_remove("RUST_LOG");
+    command
+}
+
+/// Run `cmd` with a pre-closed stdout pipe and return (exit_code, stderr).
+fn run_with_closed_stdout(cmd: &mut Command) -> (Option<i32>, String) {
+    let (reader, writer) = std::io::pipe().expect("failed to create pipe");
+    // Close the read end before the child even starts: with no readers left,
+    // every stdout write in the child fails with EPIPE immediately.
+    drop(reader);
+
+    let output = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn s3sync binary");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+fn assert_exits_zero_without_panic(code: Option<i32>, stderr: &str, what: &str) {
+    assert!(
+        !stderr.contains("panicked"),
+        "{what} must not panic on a closed stdout pipe; stderr: {stderr}"
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "{what} must exit 0 on a closed stdout pipe (None = killed by \
+         SIGPIPE); stderr: {stderr}"
+    );
+}
+
+/// Completion scripts are rendered to a buffer and written pipe-safely —
+/// clap_complete itself would panic ("failed to write completion file") if
+/// its generator wrote straight into a closed stdout.
+#[test]
+fn completion_script_with_closed_stdout_exits_zero() {
+    for shell in ["bash", "zsh", "fish"] {
+        let (code, stderr) =
+            run_with_closed_stdout(s3sync_command().args(["--auto-complete-shell", shell]));
+        assert_exits_zero_without_panic(code, &stderr, &format!("--auto-complete-shell {shell}"));
+    }
+}
+
+/// --help and --version are printed by clap, whose `Error::exit` swallows
+/// write errors ("Swallow broken pipe errors" in clap itself). Pinned here
+/// so a clap regression would be caught.
+#[test]
+fn help_and_version_with_closed_stdout_exit_zero() {
+    let (code, stderr) = run_with_closed_stdout(s3sync_command().arg("--help"));
+    assert_exits_zero_without_panic(code, &stderr, "--help");
+
+    let (code, stderr) = run_with_closed_stdout(s3sync_command().arg("--version"));
+    assert_exits_zero_without_panic(code, &stderr, "--version");
+}


### PR DESCRIPTION
…te tests, and bump to version 1.61.2.

## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell completion, help, and version output now handle closed output pipes gracefully without panicking or terminating unexpectedly.
  * Broken-pipe conditions are handled silently while other output errors are still reported.

* **Documentation**
  * Added changelog entry for version 1.61.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->