### PR TITLE
Fix/sigint exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.62.0] - 2026-08-07
+
+### Fixed
+
+- [Breaking change] A syncing interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
+  shell encoding for termination by signal) instead of 0. Previously an interrupted syncing was indistinguishable from a
+  successful one by its exit code.
 
 ## [1.61.2] - 2026-08-03
 
 ### Fixed
 
-- Generating a shell completion script into a closed pipe (e.g. `s3sync --auto-complete-shell bash | head 1` when the reader exits without consuming the script) no longer panics with `failed to write completion file: Broken pipe`.
-
+- Generating a shell completion script into a closed pipe (e.g. `s3sync --auto-complete-shell bash | head 1` when the
+  reader exits without consuming the script) no longer panics with `failed to write completion file: Broken pipe`.
 
 ## [1.61.1] - 2026-07-26
 
@@ -23,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Breaking change] The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET` environment
-  variables. These generic variable names could unintentionally override the command line arguments.
+- [Breaking change] The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET`
+  environment variables. These generic variable names could unintentionally override the command line arguments.
 
 ## [1.60.0] - 2026-07-20
 
@@ -34,8 +42,8 @@ Monthly update.
 
 - Credential-related command line options (`--source-access-key`, `--source-secret-access-key`,
   `--source-session-token`, `--target-access-key`, `--target-secret-access-key`, `--target-session-token`,
-  `--source-sse-c-key`, `--source-sse-c-key-md5`, `--target-sse-c-key`, `--target-sse-c-key-md5`) no longer
-  display their values in `--help` output when set via environment variables.
+  `--source-sse-c-key`, `--source-sse-c-key-md5`, `--target-sse-c-key`, `--target-sse-c-key-md5`) no longer display
+  their values in `--help` output when set via environment variables.
 
 ### Fixed
 
@@ -80,10 +88,9 @@ Monthly update.
 
 ### Security
 
-- Harden directory traversal check used when saving S3 objects to local
-  files: reject `.` and `..` path segments (previously only `../` and
-  `..\` were caught), and detect separators on both `/` and `\`. Does not
-  affect S3 access itself.
+- Harden directory traversal check used when saving S3 objects to local files: reject `.` and `..` path segments
+  (previously only `../` and
+  `..\` were caught), and detect separators on both `/` and `\`. Does not affect S3 access itself.
 
 ### Changed
 
@@ -148,8 +155,8 @@ Monthly update.
 
 ### Security
 
-- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21 (
-  vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls
+- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21
+  (vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls
   0.23 via `aws-smithy-http-client`, is re-enabled explicitly.
 
 ### Changed
@@ -163,8 +170,8 @@ Monthly update.
 
 ### Fixed
 
-- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early (
-  e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing
+- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early
+  (e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing
   newline no longer unwraps the write/flush result.
 
 ## [1.57.1] - 2026-03-28
@@ -178,8 +185,8 @@ Monthly update.
 
 ### Added
 
-- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline (
-  default: 10000ms, 0 to disable)
+- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline
+  (default: 10000ms, 0 to disable)
 
 ### Changed
 
@@ -283,7 +290,7 @@ Monthly update.
 
 - Refactored
 - Updated dependencies
-    - Migrated from deprecated crc64fast-nvme to crc-fast-rust(1.6.0)
+    - Migrated from deprecated crc64fast-nvme to crc-fast-rust (1.6.0)
 
 ## [1.53.0] - 2025-11-01
 
@@ -358,8 +365,8 @@ Monthly update.
 ### Changed
 
 - Added `--ignore-glacier-warnings` option  
-  Previously, when getting an object that needs to be restored from Glacier, s3sync fails with an error.
-  Now by default, s3sync shows a warning message and skips to transfer the object.  
+  Previously, when getting an object that needs to be restored from Glacier, s3sync fails with an error. Now by default,
+  s3sync shows a warning message and skips to transfer the object.  
   With this option, s3sync ignores the warning and skips to transfer the object.
 - Updated dependencies
 
@@ -510,10 +517,10 @@ Monthly update.
 - Added `--max-parallel-listing-max-depth` option  
   By default, s3sync lists objects in the source and target buckets/local files in parallel up to the second level of
   subdirectories or prefixes.  
-  And deeper levels are listed without parallelization.
-  This is because parallel listing at deeper levels may not improve performance.  
-  But in some cases, parallel listing at deeper levels may improve performance.
-  You can configure the maximum depth of parallel listing workers with `--max-parallel-listing-max-depth` option.
+  And deeper levels are listed without parallelization. This is because parallel listing at deeper levels may not
+  improve performance.  
+  But in some cases, parallel listing at deeper levels may improve performance. You can configure the maximum depth of
+  parallel listing workers with `--max-parallel-listing-max-depth` option.
 
 - Updated dependencies.
 
@@ -556,8 +563,8 @@ Monthly update.
   By default, s3sync lists objects in the source and target buckets/local in parallel (default 16 workers).  
   The parallel listing is enabled when the root has subdirectories or prefixes.  
   For example, if the source is `s3://bucket-name/prefix` and there are many objects under `prefix/dir1`,
-  `prefix/dir2`, ..., `prefix/dir16`, s3sync lists objects under these prefixes in parallel.
-  But If the source has only one subdirectory under `prefix/`, s3sync does not list objects in parallel.
+  `prefix/dir2`, ..., `prefix/dir16`, s3sync lists objects under these prefixes in parallel. But If the source has only
+  one subdirectory under `prefix/`, s3sync does not list objects in parallel.
 
   You can configure the number of parallel listing workers with `--max-parallel-listings` option.  
   If set to `1`, parallel listing is disabled.
@@ -641,7 +648,7 @@ Monthly update.
   Lua is generally recognized as a fast scripting language. Lua engine is embedded in s3sync, so you can use Lua script
   without any additional dependencies.  
   For example, you can use Lua script to implement custom preprocessing logic, such as dynamically modifying the object
-  attributes(e.g., metadata, tagging) before transferring it to S3.  
+  attributes (e.g., metadata, tagging) before transferring it to S3.  
   By default, Lua script run as safe mode, so it cannot use Lua os library functions.   
   If you want to allow more Lua libraries, you can use `--allow-lua-os-library`, `--allow-lua-unsafe-vm` option.  
   See [Lua script example](https://github.com/nidor1998/s3sync/tree/main/src/lua/script/)
@@ -679,7 +686,7 @@ Monthly update.
 ### Changed
 
 - Support a preprocess callback before uploading to S3 within the library  
-  We can use this to modify the object attributes(e.g. metadata, tagging) dynamically before uploading to s3.  
+  We can use this to modify the object attributes (e.g. metadata, tagging) dynamically before uploading to s3.  
   See [docs.rs](https://docs.rs/s3sync/latest/s3sync/) for more information.
 - Updated dependencies.
 
@@ -724,7 +731,7 @@ Monthly update.
 ### Changed
 
 - Updated documentation.
-- MSRV = 1.86.0(From 1.25.0)
+- MSRV = 1.86.0 (From 1.25.0)
 
 ## [1.25.0] - 2025-07-18
 
@@ -868,7 +875,7 @@ Monthly update.
 
 ### Changed
 
-- Refactored. Removed unnecessary unwrap().
+- Refactored. Removed unnecessary unwrap ().
 - aws-sdk-s3 = "1.91.0"
 - updated dependencies.
 
@@ -1052,7 +1059,7 @@ Added `--disable-content-md5-header` option. It disables the ETag verification f
 
 ### Added
 
-- Added Additional checksum(SHA256/SHA1/CRC32/CRC32C) based incremental transfer `--check-additional-checksum` option.
+- Added Additional checksum (SHA256/SHA1/CRC32/CRC32C) based incremental transfer `--check-additional-checksum` option.
 - Added `get_errors_and_consume()` to `Pipeline` to get errors.
 
 ### Changed
@@ -1074,7 +1081,7 @@ Added `--disable-content-md5-header` option. It disables the ETag verification f
 
 ### Added
 
-- Added [Stalled-stream protection](https://github.com/awslabs/aws-sdk-rust/discussions/956) support(enabled by
+- Added [Stalled-stream protection](https://github.com/awslabs/aws-sdk-rust/discussions/956) support (enabled by
   default).
 - Added Express One Zone integration tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
-to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.62.0] - 2026-08-07
+## [1.62.0] - 2026-08-08
 
-### Fixed
+### Changed
 
-- [Breaking change] An interrupted sync caused by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
-  shell encoding for termination by signal) instead of 0. Previously an interrupted syncing was indistinguishable from a
-  successful one by its exit code.
+- [Breaking change] The s3sync CLI now exits with code 130 (128 + SIGINT, the conventional shell encoding for
+  termination by signal) when a sync is interrupted by Ctrl+C (SIGINT). Previously an interrupted run exited with
+  code 0, 3 or 1 depending on when the interrupt arrived, so it could be indistinguishable from a successful run.
+  This change affects only the CLI binary; the library API is unchanged.
 
 ## [1.61.2] - 2026-08-03
 
 ### Fixed
 
-- Generating a shell completion script into a closed pipe (e.g. `s3sync --auto-complete-shell bash | head 1` when the
-  reader exits without consuming the script) no longer panics with `failed to write completion file: Broken pipe`.
+- Generating a shell completion script into a closed pipe (e.g. `s3sync --auto-complete-shell bash | head 1` when the reader exits without consuming the script) no longer panics with `failed to write completion file: Broken pipe`.
+
 
 ## [1.61.1] - 2026-07-26
 
@@ -31,8 +32,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- [Breaking change] The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET`
-  environment variables. These generic variable names could unintentionally override the command line arguments.
+- [Breaking change] The positional `source`/`target` arguments no longer read their values from the `SOURCE`/`TARGET` environment
+  variables. These generic variable names could unintentionally override the command line arguments.
 
 ## [1.60.0] - 2026-07-20
 
@@ -42,8 +43,8 @@ Monthly update.
 
 - Credential-related command line options (`--source-access-key`, `--source-secret-access-key`,
   `--source-session-token`, `--target-access-key`, `--target-secret-access-key`, `--target-session-token`,
-  `--source-sse-c-key`, `--source-sse-c-key-md5`, `--target-sse-c-key`, `--target-sse-c-key-md5`) no longer display
-  their values in `--help` output when set via environment variables.
+  `--source-sse-c-key`, `--source-sse-c-key-md5`, `--target-sse-c-key`, `--target-sse-c-key-md5`) no longer
+  display their values in `--help` output when set via environment variables.
 
 ### Fixed
 
@@ -88,9 +89,10 @@ Monthly update.
 
 ### Security
 
-- Harden directory traversal check used when saving S3 objects to local files: reject `.` and `..` path segments
-  (previously only `../` and
-  `..\` were caught), and detect separators on both `/` and `\`. Does not affect S3 access itself.
+- Harden directory traversal check used when saving S3 objects to local
+  files: reject `.` and `..` path segments (previously only `../` and
+  `..\` were caught), and detect separators on both `/` and `\`. Does not
+  affect S3 access itself.
 
 ### Changed
 
@@ -155,8 +157,8 @@ Monthly update.
 
 ### Security
 
-- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21
-  (vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls
+- Disabled default features on `aws-config` and `aws-sdk-s3` to drop the legacy `rustls` alias that pulls rustls 0.21 (
+  vulnerable rustls-webpki 0.101.x, RUSTSEC-2026-0098). The modern `default-https-client` feature, which uses rustls
   0.23 via `aws-smithy-http-client`, is re-enabled explicitly.
 
 ### Changed
@@ -170,8 +172,8 @@ Monthly update.
 
 ### Fixed
 
-- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early
-  (e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing
+- Stop panicking with "failed printing to stdout: Broken pipe" when output is piped to a consumer that closes early (
+  e.g. `s3sync ... | wc -l` followed by Ctrl-C). Tracing writes now swallow `BrokenPipe`, and the indicator's trailing
   newline no longer unwraps the write/flush result.
 
 ## [1.57.1] - 2026-03-28
@@ -185,8 +187,8 @@ Monthly update.
 
 ### Added
 
-- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline
-  (default: 10000ms, 0 to disable)
+- Added `--lua-callback-timeout-milliseconds` option to prevent runaway Lua scripts from blocking the sync pipeline (
+  default: 10000ms, 0 to disable)
 
 ### Changed
 
@@ -290,7 +292,7 @@ Monthly update.
 
 - Refactored
 - Updated dependencies
-    - Migrated from deprecated crc64fast-nvme to crc-fast-rust (1.6.0)
+    - Migrated from deprecated crc64fast-nvme to crc-fast-rust(1.6.0)
 
 ## [1.53.0] - 2025-11-01
 
@@ -365,8 +367,8 @@ Monthly update.
 ### Changed
 
 - Added `--ignore-glacier-warnings` option  
-  Previously, when getting an object that needs to be restored from Glacier, s3sync fails with an error. Now by default,
-  s3sync shows a warning message and skips to transfer the object.  
+  Previously, when getting an object that needs to be restored from Glacier, s3sync fails with an error.
+  Now by default, s3sync shows a warning message and skips to transfer the object.  
   With this option, s3sync ignores the warning and skips to transfer the object.
 - Updated dependencies
 
@@ -517,10 +519,10 @@ Monthly update.
 - Added `--max-parallel-listing-max-depth` option  
   By default, s3sync lists objects in the source and target buckets/local files in parallel up to the second level of
   subdirectories or prefixes.  
-  And deeper levels are listed without parallelization. This is because parallel listing at deeper levels may not
-  improve performance.  
-  But in some cases, parallel listing at deeper levels may improve performance. You can configure the maximum depth of
-  parallel listing workers with `--max-parallel-listing-max-depth` option.
+  And deeper levels are listed without parallelization.
+  This is because parallel listing at deeper levels may not improve performance.  
+  But in some cases, parallel listing at deeper levels may improve performance.
+  You can configure the maximum depth of parallel listing workers with `--max-parallel-listing-max-depth` option.
 
 - Updated dependencies.
 
@@ -563,8 +565,8 @@ Monthly update.
   By default, s3sync lists objects in the source and target buckets/local in parallel (default 16 workers).  
   The parallel listing is enabled when the root has subdirectories or prefixes.  
   For example, if the source is `s3://bucket-name/prefix` and there are many objects under `prefix/dir1`,
-  `prefix/dir2`, ..., `prefix/dir16`, s3sync lists objects under these prefixes in parallel. But If the source has only
-  one subdirectory under `prefix/`, s3sync does not list objects in parallel.
+  `prefix/dir2`, ..., `prefix/dir16`, s3sync lists objects under these prefixes in parallel.
+  But If the source has only one subdirectory under `prefix/`, s3sync does not list objects in parallel.
 
   You can configure the number of parallel listing workers with `--max-parallel-listings` option.  
   If set to `1`, parallel listing is disabled.
@@ -648,7 +650,7 @@ Monthly update.
   Lua is generally recognized as a fast scripting language. Lua engine is embedded in s3sync, so you can use Lua script
   without any additional dependencies.  
   For example, you can use Lua script to implement custom preprocessing logic, such as dynamically modifying the object
-  attributes (e.g., metadata, tagging) before transferring it to S3.  
+  attributes(e.g., metadata, tagging) before transferring it to S3.  
   By default, Lua script run as safe mode, so it cannot use Lua os library functions.   
   If you want to allow more Lua libraries, you can use `--allow-lua-os-library`, `--allow-lua-unsafe-vm` option.  
   See [Lua script example](https://github.com/nidor1998/s3sync/tree/main/src/lua/script/)
@@ -686,7 +688,7 @@ Monthly update.
 ### Changed
 
 - Support a preprocess callback before uploading to S3 within the library  
-  We can use this to modify the object attributes (e.g. metadata, tagging) dynamically before uploading to s3.  
+  We can use this to modify the object attributes(e.g. metadata, tagging) dynamically before uploading to s3.  
   See [docs.rs](https://docs.rs/s3sync/latest/s3sync/) for more information.
 - Updated dependencies.
 
@@ -731,7 +733,7 @@ Monthly update.
 ### Changed
 
 - Updated documentation.
-- MSRV = 1.86.0 (From 1.25.0)
+- MSRV = 1.86.0(From 1.25.0)
 
 ## [1.25.0] - 2025-07-18
 
@@ -875,7 +877,7 @@ Monthly update.
 
 ### Changed
 
-- Refactored. Removed unnecessary unwrap ().
+- Refactored. Removed unnecessary unwrap().
 - aws-sdk-s3 = "1.91.0"
 - updated dependencies.
 
@@ -1059,7 +1061,7 @@ Added `--disable-content-md5-header` option. It disables the ETag verification f
 
 ### Added
 
-- Added Additional checksum (SHA256/SHA1/CRC32/CRC32C) based incremental transfer `--check-additional-checksum` option.
+- Added Additional checksum(SHA256/SHA1/CRC32/CRC32C) based incremental transfer `--check-additional-checksum` option.
 - Added `get_errors_and_consume()` to `Pipeline` to get errors.
 
 ### Changed
@@ -1081,7 +1083,7 @@ Added `--disable-content-md5-header` option. It disables the ETag verification f
 
 ### Added
 
-- Added [Stalled-stream protection](https://github.com/awslabs/aws-sdk-rust/discussions/956) support (enabled by
+- Added [Stalled-stream protection](https://github.com/awslabs/aws-sdk-rust/discussions/956) support(enabled by
   default).
 - Added Express One Zone integration tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- [Breaking change] A syncing interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
+- [Breaking change] An interrupted sync caused by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
   shell encoding for termination by signal) instead of 0. Previously an interrupted syncing was indistinguishable from a
   successful one by its exit code.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,7 +2717,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3sync"
-version = "1.61.2"
+version = "1.62.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3sync"
-version = "1.61.2"
+version = "1.62.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Reliable, flexible, and fast synchronization tool for S3."

--- a/FULL_README.md
+++ b/FULL_README.md
@@ -523,7 +523,8 @@ You can check the synchronization status of the object's tagging, metadata, anno
 `--report-tagging-sync-status` and `--report-annotations-sync-status` option.
 
 Note: For reporting, s3sync uses a special process exit code. `0` If all objects are synchronized correctly. `3` If some
-objects are not synchronized correctly.
+objects are not synchronized correctly. If reporting is interrupted by Ctrl-C, s3sync exits with code `130` and no
+summary is shown.
 
 Note: It needs additional API calls to get the metadata, checksum, and tags of each object.
 
@@ -1148,6 +1149,7 @@ For more information, see [mlua feature flags](https://github.com/mlua-rs/mlua#f
 - 1: Exit with error
 - 2: Invalid arguments
 - 3: Exit with warning
+- 130: Interrupted by Ctrl-C (SIGINT)
 - 101: Abnormal termination (Rust panic, it's a bug of s3sync)
 
 ## Advanced options

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ correctly.
   s3sync is designed to be used in CI/CD pipelines.
     - JSON tracing(logging) support(`--json-tracing` option)
     - Explicit exit code  
-      `0` for success, `1` for error, `2` for invalid arguments, `3` for warnings(e.g., ETag mismatch), `101` for
-      abnormal termination (e.g., Rust panic, it's a bug of s3sync)
+      `0` for success, `1` for error, `2` for invalid arguments, `3` for warnings(e.g., ETag mismatch), `130` for
+      interruption by Ctrl-C (SIGINT), `101` for abnormal termination (e.g., Rust panic, it's a bug of s3sync)
     - Supports all options via environment variables
 
 - Multiple platforms support  

--- a/src/bin/s3sync/cli/ctrl_c_handler/mod.rs
+++ b/src/bin/s3sync/cli/ctrl_c_handler/mod.rs
@@ -1,8 +1,16 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error, warn};
 
 use s3sync::types::token::PipelineCancellationToken;
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -14,6 +22,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         warn!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {

--- a/src/bin/s3sync/cli/ctrl_c_handler/mod.rs
+++ b/src/bin/s3sync/cli/ctrl_c_handler/mod.rs
@@ -55,6 +55,7 @@ mod tests {
         init_dummy_tracing_subscriber();
 
         let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
 
         let cancellation_token = token::create_pipeline_cancellation_token();
 
@@ -64,11 +65,16 @@ mod tests {
         ))
         .await;
 
+        assert!(!is_ctrl_c_received());
+
         kill_sigint_to_self();
 
         join_handle.await.unwrap();
 
         assert!(cancellation_token.is_cancelled());
+        assert!(is_ctrl_c_received());
+
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[tokio::test]
@@ -76,6 +82,7 @@ mod tests {
         init_dummy_tracing_subscriber();
 
         let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
 
         let cancellation_token = token::create_pipeline_cancellation_token();
 
@@ -85,6 +92,22 @@ mod tests {
         join_handle.await.unwrap();
 
         assert!(cancellation_token.is_cancelled());
+        assert!(!is_ctrl_c_received());
+    }
+
+    #[tokio::test]
+    async fn is_ctrl_c_received_reflects_flag_state() {
+        init_dummy_tracing_subscriber();
+
+        let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
+        assert!(!is_ctrl_c_received());
+
+        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
+        assert!(is_ctrl_c_received());
+
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[cfg(target_family = "unix")]

--- a/src/bin/s3sync/cli/mod.rs
+++ b/src/bin/s3sync/cli/mod.rs
@@ -22,6 +22,7 @@ const EXIT_CODE_ERROR: i32 = 1;
 #[allow(dead_code)]
 const EXIT_CODE_INVALID_ARGS: i32 = 2;
 const EXIT_CODE_WARNING: i32 = 3;
+const SIGINT_EXIT_CODE: i32 = 130;
 
 pub async fn run(mut config: Config) -> Result<()> {
     #[allow(unused_assignments)]
@@ -103,6 +104,12 @@ pub async fn run(mut config: Config) -> Result<()> {
         indicator_join_handle.await?;
 
         let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
+
+        if ctrl_c_handler::is_ctrl_c_received() {
+            debug!(duration_sec = duration_sec, "deletion cancelled by user.");
+            std::process::exit(SIGINT_EXIT_CODE);
+        }
+
         if pipeline.has_error() {
             error!(duration_sec = duration_sec, "s3sync failed.");
 

--- a/src/bin/s3sync/cli/mod.rs
+++ b/src/bin/s3sync/cli/mod.rs
@@ -106,7 +106,7 @@ pub async fn run(mut config: Config) -> Result<()> {
         let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
 
         if ctrl_c_handler::is_ctrl_c_received() {
-            debug!(duration_sec = duration_sec, "deletion cancelled by user.");
+            debug!(duration_sec = duration_sec, "sync cancelled by user.");
             std::process::exit(SIGINT_EXIT_CODE);
         }
 


### PR DESCRIPTION
## Contributing

While this project began as a personal hobby, it has been built with careful attention to production-quality standards.

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Ctrl-C interruption handling during synchronization.
  * The CLI now exits with status code 130 when interrupted and omits the final summary.

* **Documentation**
  * Documented SIGINT interruption behavior and exit code 130 in the README and changelog.
  * Clarified that the library API remains unchanged.

* **Chores**
  * Updated the application version to 1.62.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->